### PR TITLE
1408 publisher v3 functionality question pages

### DIFF
--- a/src/eq_schema/block-types/Introduction/index.js
+++ b/src/eq_schema/block-types/Introduction/index.js
@@ -11,7 +11,7 @@ const getSimpleText = (content, ctx) =>
   flow(convertPipes(ctx), getInnerHTMLWithPiping)(content);
 
 const getComplexText = (content, ctx) => {
-  const result = processContent(ctx)(content);
+  const result = processContent(ctx)(content)("content");
   if (result) {
     return result.content;
   }
@@ -51,17 +51,19 @@ module.exports = class Introduction {
           contents: getComplexText(description, ctx)
         }))
     };
-    let tertiaryContent
+    let tertiaryContent;
     if (tertiaryDescription) {
-      tertiaryContent = getComplexText(tertiaryDescription, ctx)[0]
+      tertiaryContent = getComplexText(tertiaryDescription, ctx)[0];
     }
     this.secondary_content = [
       {
         id: "secondary-content",
-        contents: [{
-          title: getSimpleText(tertiaryTitle, ctx), 
-          ...tertiaryContent,
-        }]
+        contents: [
+          {
+            title: getSimpleText(tertiaryTitle, ctx),
+            ...tertiaryContent
+          }
+        ]
       }
     ];
   }

--- a/src/eq_schema/builders/confirmationPage/ConfirmationPage.js
+++ b/src/eq_schema/builders/confirmationPage/ConfirmationPage.js
@@ -35,24 +35,20 @@ const buildAuthorConfirmationQuestion = (
       expressions: [
         {
           left: {
-            id: `confirmation-answer-for-${page.id}`,
-            type: RADIO
+            answerId: `confirmation-answer-for-${page.id}`,
+            type: 'Answer'
           },
-          condition: "OneOf",
+          condition: "Equal",
           right: {
-            options: [
-              {
-                label: page.confirmation.negative.label
-              }
-            ]
+            customValue: {
+              number: page.confirmation.negative.label
+            }    
           }
         }
       ]
     },
     destination: {
-      page: {
-        id: page.id
-      }
+      pageId: page.id
     }
   };
 

--- a/src/eq_schema/builders/routing2/basicQuestionnaireJSON.js
+++ b/src/eq_schema/builders/routing2/basicQuestionnaireJSON.js
@@ -52,6 +52,20 @@ const questionnaireJson = {
               id: "3",
               type: "Number",
               label: "Answer 3"
+            },
+            {
+              id: "4",
+              type: "Checkbox",
+              options: [
+                {
+                  id: "123",
+                  label: "red",
+                },
+                {
+                  id: "456",
+                  label: "white",
+                }
+              ]
             }
           ]
         }

--- a/src/eq_schema/builders/routing2/index.js
+++ b/src/eq_schema/builders/routing2/index.js
@@ -22,7 +22,7 @@ module.exports = (routing, pageId, groupId, ctx) => {
     );
     if (rule.expressionGroup.operator === AND) {
       const when = rule.expressionGroup.expressions.map(expression =>
-        translateBinaryExpression(expression)
+        translateBinaryExpression(expression, ctx)
       );
       runnerRules = [
         {
@@ -37,7 +37,7 @@ module.exports = (routing, pageId, groupId, ctx) => {
         return {
           goto: {
             ...destination,
-            when: [translateBinaryExpression(expression)]
+            when: [translateBinaryExpression(expression, ctx)]
           }
         };
       });

--- a/src/eq_schema/builders/routing2/index.test.js
+++ b/src/eq_schema/builders/routing2/index.test.js
@@ -1,5 +1,4 @@
 const translateAuthorRouting = require("./");
-const { RADIO, CURRENCY } = require("../../../constants/answerTypes");
 const { questionnaireJson } = require("./basicQuestionnaireJSON");
 const { AND, OR } = require("../../../constants/routingOperators");
 
@@ -21,12 +20,14 @@ describe("Routing2", () => {
             expressions: [
               {
                 left: {
-                  id: "1",
-                  type: CURRENCY
+                  answerId: "1",
+                  type: "Answer"
                 },
                 condition: "Equal",
                 right: {
-                  number: 5
+                  customValue: {
+                    number: 5
+                  }
                 }
               }
             ]
@@ -41,19 +42,16 @@ describe("Routing2", () => {
             expressions: [
               {
                 left: {
-                  id: "2",
-                  type: RADIO
+                  answerId: "2",
+                  type: "Answer"
                 },
                 condition: "OneOf",
                 right: {
-                  options: [
-                    {
-                      label: "red"
-                    },
-                    {
-                      label: "white"
-                    }
+                  type: "SelectedOptions",
+                  optionIds: [
+                    "123", "456"
                   ]
+                  
                 }
               }
             ]
@@ -64,9 +62,7 @@ describe("Routing2", () => {
         }
       ],
       else: {
-        page: {
-          id: "3"
-        }
+        pageId: "3"
       }
     };
 
@@ -127,23 +123,14 @@ describe("Routing2", () => {
             expressions: [
               {
                 left: {
-                  id: "1",
-                  type: RADIO,
-                  options: [
-                    {
-                      label: "A"
-                    },
-                    {
-                      label: "B"
-                    }
-                  ]
+                  answerId: "1",
+                  type: "Answer",
                 },
                 condition: "OneOf",
                 right: {
-                  options: [
-                    {
-                      label: "A"
-                    }
+                  type: "SelectedOptions",
+                  optionIds: [
+                    "123", "456"
                   ]
                 }
               }
@@ -159,23 +146,14 @@ describe("Routing2", () => {
             expressions: [
               {
                 left: {
-                  id: "2",
-                  type: RADIO,
-                  options: [
-                    {
-                      label: "D"
-                    },
-                    {
-                      label: "E"
-                    }
-                  ]
+                  answerId: "2",
+                  type: "Answer",
                 },
                 condition: "OneOf",
                 right: {
-                  options: [
-                    {
-                      label: "E"
-                    }
+                  type: "SelectedOptions",
+                  optionIds: [
+                    "123", "456"
                   ]
                 }
               }
@@ -187,9 +165,7 @@ describe("Routing2", () => {
         }
       ],
       else: {
-        page: {
-          id: "3"
-        }
+        pageId: "3"
       }
     };
     const runnerRouting = translateAuthorRouting(authorRouting, "1", "1", ctx);
@@ -201,7 +177,7 @@ describe("Routing2", () => {
             {
               id: "answer1",
               condition: "contains any",
-              values: ["A"]
+              values: ["red", "white"]
             }
           ]
         }
@@ -213,7 +189,7 @@ describe("Routing2", () => {
             {
               id: "answer2",
               condition: "contains any",
-              values: ["E"]
+              values: ["red", "white"]
             }
           ]
         }

--- a/src/eq_schema/builders/routing2/translateBinaryExpression/index.js
+++ b/src/eq_schema/builders/routing2/translateBinaryExpression/index.js
@@ -1,8 +1,20 @@
 const conditionConverter = require("../../../../utils/convertRoutingConditions");
+const { flatMap, filter } = require("lodash");
 
 const authorConditions = {
   UNANSWERED: "Unanswered"
 };
+
+const getOptionsFromQuestionaire = (questionnaire) => {
+  const pages = flatMap(questionnaire.sections, 'pages')
+  const answers = flatMap(pages, 'answers')
+  return flatMap(filter(answers, 'options'), 'options')
+}
+
+const getOptionValues = (optionIds, questionnaire) => {
+  const options = getOptionsFromQuestionaire(questionnaire)
+  return optionIds.map((id) => filter(options, { id })[0].label)
+}
 
 const buildAnswerBinaryExpression = ({ left, condition, right }, ctx) => {
   const returnVal = {
@@ -15,8 +27,7 @@ const buildAnswerBinaryExpression = ({ left, condition, right }, ctx) => {
   }
 
   if (right.type === "SelectedOptions") {
-    // ToDo:- add lookup for option values
-    returnVal.values = right.optionIds
+    returnVal.values = getOptionValues(right.optionIds, ctx.questionnaireJson)
   } else {
     returnVal.value = right.customValue.number;
   }
@@ -24,7 +35,7 @@ const buildAnswerBinaryExpression = ({ left, condition, right }, ctx) => {
   return returnVal;
 };
 
-const translateBinaryExpression = ( binaryExpression, ctx ) => {
+const translateBinaryExpression = (binaryExpression, ctx) => {
   if (binaryExpression.left.type === "Answer") {
     return buildAnswerBinaryExpression(binaryExpression, ctx);
   } else {

--- a/src/eq_schema/builders/routing2/translateBinaryExpression/index.js
+++ b/src/eq_schema/builders/routing2/translateBinaryExpression/index.js
@@ -1,68 +1,32 @@
-const { isEmpty } = require("lodash");
-
-const {
-  RADIO,
-  CURRENCY,
-  NUMBER,
-  PERCENTAGE,
-  UNIT,
-  CHECKBOX
-} = require("../../../../constants/answerTypes");
 const conditionConverter = require("../../../../utils/convertRoutingConditions");
 
 const authorConditions = {
   UNANSWERED: "Unanswered"
 };
 
-const buildRadioAnswerBinaryExpression = ({ left, right }) => {
-  if (isEmpty(right.options)) {
-    return {
-      id: `answer${left.id}`,
-      condition: "not set"
-    };
-  }
-  return {
-    id: `answer${left.id}`,
-    condition: "contains any",
-    values: right.options.map(op => op.label)
-  };
-};
-
-const buildCheckboxAnswerBinaryExpression = ({ left, right, condition }) => {
+const buildAnswerBinaryExpression = ({ left, condition, right }, ctx) => {
   const returnVal = {
-    id: `answer${left.id}`,
+    id: `answer${left.answerId}`,
     condition: conditionConverter(condition)
   };
 
-  if (condition !== authorConditions.UNANSWERED) {
-    returnVal.values = right.options.map(op => op.label);
+  if (condition === authorConditions.UNANSWERED) {
+    return returnVal;
+  }
+
+  if (right.type === "SelectedOptions") {
+    // ToDo:- add lookup for option values
+    returnVal.values = right.optionIds
+  } else {
+    returnVal.value = right.customValue.number;
   }
 
   return returnVal;
 };
 
-const buildBasicAnswerBinaryExpression = ({ left, condition, right }) => {
-  const returnVal = {
-    id: `answer${left.id}`,
-    condition: conditionConverter(condition)
-  };
-
-  if (condition !== authorConditions.UNANSWERED) {
-    returnVal.value = right.number;
-  }
-
-  return returnVal;
-};
-
-const translateBinaryExpression = binaryExpression => {
-  if (binaryExpression.left.type === RADIO) {
-    return buildRadioAnswerBinaryExpression(binaryExpression);
-  } else if (binaryExpression.left.type === CHECKBOX) {
-    return buildCheckboxAnswerBinaryExpression(binaryExpression);
-  } else if (
-    [CURRENCY, NUMBER, PERCENTAGE, UNIT].includes(binaryExpression.left.type)
-  ) {
-    return buildBasicAnswerBinaryExpression(binaryExpression);
+const translateBinaryExpression = ( binaryExpression, ctx ) => {
+  if (binaryExpression.left.type === "Answer") {
+    return buildAnswerBinaryExpression(binaryExpression, ctx);
   } else {
     throw new Error(
       `${binaryExpression.left.type} is not a valid routing answer type`

--- a/src/eq_schema/builders/routing2/translateBinaryExpression/index.test.js
+++ b/src/eq_schema/builders/routing2/translateBinaryExpression/index.test.js
@@ -1,11 +1,3 @@
-const {
-  RADIO,
-  CURRENCY,
-  NUMBER,
-  PERCENTAGE,
-  CHECKBOX,
-  UNIT
-} = require("../../../../constants/answerTypes");
 const { questionnaireJson } = require("../basicQuestionnaireJSON");
 
 const translateBinaryExpression = require(".");
@@ -23,26 +15,28 @@ describe("Should build a runner representation of a binary expression", () => {
       }
     };
 
-    expect(() => translateBinaryExpression(expression, {questionnaireJson} )).toThrow(
-      "not a valid routing answer type"
-    );
+    expect(() =>
+      translateBinaryExpression(expression, { questionnaireJson })
+    ).toThrow("not a valid routing answer type");
   });
   describe("With Radio answers", () => {
     const buildBinaryExpression = (optionIds, condition) => ({
       left: {
         answerId: "1",
-        type: "Answer",
+        type: "Answer"
       },
       condition,
       right: {
         type: "SelectedOptions",
         optionIds
-      } 
+      }
     });
 
     it("With a radio answer and single selected option", () => {
       const expression = buildBinaryExpression(["123"], "OneOf");
-      const runnerExpression = translateBinaryExpression(expression, {questionnaireJson});
+      const runnerExpression = translateBinaryExpression(expression, {
+        questionnaireJson
+      });
 
       expect(runnerExpression).toMatchObject({
         id: "answer1",
@@ -53,7 +47,9 @@ describe("Should build a runner representation of a binary expression", () => {
 
     it("With a radio answer and no selected options", () => {
       const expression = buildBinaryExpression(["123", "456"], "Unanswered");
-      const runnerExpression = translateBinaryExpression(expression, {questionnaireJson});
+      const runnerExpression = translateBinaryExpression(expression, {
+        questionnaireJson
+      });
 
       expect(runnerExpression).toMatchObject({
         condition: "not set",
@@ -64,7 +60,9 @@ describe("Should build a runner representation of a binary expression", () => {
     it("With a radio answer and multiple selected options", () => {
       const expression = buildBinaryExpression(["123", "456"], "OneOf");
 
-      const runnerExpression = translateBinaryExpression(expression, {questionnaireJson});
+      const runnerExpression = translateBinaryExpression(expression, {
+        questionnaireJson
+      });
       expect(runnerExpression).toMatchObject({
         id: "answer1",
         condition: "contains any",
@@ -82,12 +80,14 @@ describe("Should build a runner representation of a binary expression", () => {
         },
         condition: "Equal",
         right: {
-          customValue:{
-            number: 5,
+          customValue: {
+            number: 5
           }
         }
       };
-      const runnerExpression = translateBinaryExpression(expression, {questionnaireJson});
+      const runnerExpression = translateBinaryExpression(expression, {
+        questionnaireJson
+      });
       expect(runnerExpression).toMatchObject({
         id: "answer1",
         condition: "equals",
@@ -103,13 +103,15 @@ describe("Should build a runner representation of a binary expression", () => {
         },
         condition: "Unanswered",
         right: {
-          customValue:{
-            number: 5,
+          customValue: {
+            number: 5
           }
         }
       };
 
-      const runnerExpression = translateBinaryExpression(expression, {questionnaireJson});
+      const runnerExpression = translateBinaryExpression(expression, {
+        questionnaireJson
+      });
 
       expect(runnerExpression).toMatchObject({
         id: "answer1",

--- a/src/eq_schema/builders/routing2/translateBinaryExpression/index.test.js
+++ b/src/eq_schema/builders/routing2/translateBinaryExpression/index.test.js
@@ -6,6 +6,7 @@ const {
   CHECKBOX,
   UNIT
 } = require("../../../../constants/answerTypes");
+const { questionnaireJson } = require("../basicQuestionnaireJSON");
 
 const translateBinaryExpression = require(".");
 
@@ -18,61 +19,41 @@ describe("Should build a runner representation of a binary expression", () => {
       },
       condition: "Equal",
       right: {
-        number: 5,
-        __typeName: "CustomValue2"
+        number: 5
       }
     };
 
-    expect(() => translateBinaryExpression(expression)).toThrow(
+    expect(() => translateBinaryExpression(expression, {questionnaireJson} )).toThrow(
       "not a valid routing answer type"
     );
   });
   describe("With Radio answers", () => {
-    const buildBinaryExpression = (optionsArray, condition) => ({
+    const buildBinaryExpression = (optionIds, condition) => ({
       left: {
-        id: "1",
-        type: RADIO,
-        options: [
-          {
-            id: "1",
-            value: "yes"
-          },
-          {
-            id: "2",
-            value: "no"
-          },
-          {
-            id: "3",
-            value: "maybe"
-          }
-        ]
+        answerId: "1",
+        type: "Answer",
       },
       condition,
       right: {
-        options: optionsArray,
-        __typeName: "SelectedOptions2"
-      }
+        type: "SelectedOptions",
+        optionIds
+      } 
     });
 
     it("With a radio answer and single selected option", () => {
-      const expression = buildBinaryExpression(
-        [{ id: "2", label: "no" }],
-        "OneOf"
-      );
-
-      const runnerExpression = translateBinaryExpression(expression);
+      const expression = buildBinaryExpression(["123"], "OneOf");
+      const runnerExpression = translateBinaryExpression(expression, {questionnaireJson});
 
       expect(runnerExpression).toMatchObject({
         id: "answer1",
         condition: "contains any",
-        values: ["no"]
+        values: ["red"]
       });
     });
 
     it("With a radio answer and no selected options", () => {
-      const expression = buildBinaryExpression([], "OneOf");
-
-      const runnerExpression = translateBinaryExpression(expression);
+      const expression = buildBinaryExpression(["123", "456"], "Unanswered");
+      const runnerExpression = translateBinaryExpression(expression, {questionnaireJson});
 
       expect(runnerExpression).toMatchObject({
         condition: "not set",
@@ -81,141 +62,58 @@ describe("Should build a runner representation of a binary expression", () => {
     });
 
     it("With a radio answer and multiple selected options", () => {
-      const expression = buildBinaryExpression(
-        [
-          { id: "2", label: "no" },
-          { id: "3", label: "maybe" }
-        ],
-        "OneOf"
-      );
+      const expression = buildBinaryExpression(["123", "456"], "OneOf");
 
-      const runnerExpression = translateBinaryExpression(expression);
+      const runnerExpression = translateBinaryExpression(expression, {questionnaireJson});
       expect(runnerExpression).toMatchObject({
         id: "answer1",
         condition: "contains any",
-        values: ["no", "maybe"]
-      });
-    });
-  });
-
-  describe("With Checkbox answers", () => {
-    const buildBinaryExpression = (optionsArray, condition) => ({
-      left: {
-        id: "1",
-        type: CHECKBOX,
-        options: [
-          {
-            id: "1",
-            value: "yes"
-          },
-          {
-            id: "2",
-            value: "no"
-          },
-          {
-            id: "3",
-            value: "maybe"
-          }
-        ]
-      },
-      condition,
-      right: {
-        options: optionsArray,
-        __typeName: "SelectedOptions2"
-      }
-    });
-
-    it("With a checkbox answer and all of", () => {
-      const expression = buildBinaryExpression(
-        [
-          { id: "1", label: "yes" },
-          { id: "2", label: "no" }
-        ],
-        "AllOf"
-      );
-
-      const runnerExpression = translateBinaryExpression(expression);
-
-      expect(runnerExpression).toMatchObject({
-        id: "answer1",
-        condition: "contains all",
-        values: ["yes", "no"]
-      });
-    });
-
-    it("With a checkbox answer and any of", () => {
-      const expression = buildBinaryExpression(
-        [
-          { id: "1", label: "yes" },
-          { id: "2", label: "no" }
-        ],
-        "AnyOf"
-      );
-
-      const runnerExpression = translateBinaryExpression(expression);
-
-      expect(runnerExpression).toMatchObject({
-        id: "answer1",
-        condition: "contains any",
-        values: ["yes", "no"]
-      });
-    });
-
-    it("can translate unanswered question routing from Author to Runner", () => {
-      const expression = buildBinaryExpression([], "Unanswered");
-
-      const runnerExpression = translateBinaryExpression(expression);
-
-      expect(runnerExpression).toMatchObject({
-        id: "answer1",
-        condition: "not set"
+        values: ["red", "white"]
       });
     });
   });
 
   describe("With Number based answers", () => {
     it("supports a custom value", () => {
-      [NUMBER, CURRENCY, PERCENTAGE].forEach(type => {
-        const expression = {
-          left: {
-            id: "1",
-            type
-          },
-          condition: "Equal",
-          right: {
+      const expression = {
+        left: {
+          answerId: "1",
+          type: "Answer"
+        },
+        condition: "Equal",
+        right: {
+          customValue:{
             number: 5,
-            __typeName: "CustomValue2"
           }
-        };
-        const runnerExpression = translateBinaryExpression(expression);
-        expect(runnerExpression).toMatchObject({
-          id: "answer1",
-          condition: "equals",
-          value: 5
-        });
+        }
+      };
+      const runnerExpression = translateBinaryExpression(expression, {questionnaireJson});
+      expect(runnerExpression).toMatchObject({
+        id: "answer1",
+        condition: "equals",
+        value: 5
       });
     });
 
     it("can translate unanswered question routing from Author to Runner for all numeric types", () => {
-      [NUMBER, CURRENCY, PERCENTAGE, UNIT].forEach(type => {
-        const expression = {
-          left: {
-            id: "1",
-            type
-          },
-          condition: "Unanswered",
-          right: {
+      const expression = {
+        left: {
+          answerId: "1",
+          type: "Answer"
+        },
+        condition: "Unanswered",
+        right: {
+          customValue:{
             number: 5,
-            __typeName: "CustomValue2"
           }
-        };
+        }
+      };
 
-        const runnerExpression = translateBinaryExpression(expression);
+      const runnerExpression = translateBinaryExpression(expression, {questionnaireJson});
 
-        expect(runnerExpression).toMatchObject({
-          id: "answer1",
-          condition: "not set"
-        });
+      expect(runnerExpression).toMatchObject({
+        id: "answer1",
+        condition: "not set"
       });
     });
   });

--- a/src/eq_schema/builders/routing2/translateRoutingDestination/index.js
+++ b/src/eq_schema/builders/routing2/translateRoutingDestination/index.js
@@ -1,10 +1,10 @@
 const { flatMap, get, findIndex, isNil } = require("lodash");
 
 const getAbsoluteDestination = destination => {
-  if (destination.page) {
-    return { block: `block${destination.page.id}` };
+  if (destination.pageId) {
+    return { block: `block${destination.pageId}` };
   }
-  return { group: `group${destination.section.id}` };
+  return { group: `group${destination.sectionId}` };
 };
 
 const getNextPageDestination = (pageId, ctx) => {
@@ -52,7 +52,7 @@ const getLogicalDestination = (pageId, { logical }, ctx) => {
 const translateRoutingDestination = (destination, pageId, ctx) => {
   if (destination.logical) {
     return getLogicalDestination(pageId, destination, ctx);
-  } else if (destination.page || destination.section) {
+  } else if (destination.pageId || destination.sectionId) {
     return getAbsoluteDestination(destination);
   } else {
     throw new Error(`${destination} is not a valid destination object`);

--- a/src/eq_schema/builders/routing2/translateRoutingDestination/index.test.js
+++ b/src/eq_schema/builders/routing2/translateRoutingDestination/index.test.js
@@ -4,9 +4,7 @@ const { questionnaireJson, questionnaireJsonWithSummary } = require("../basicQue
 describe("Translation of a routing destination", () => {
   it("should translate an absolute destination to another Page", () => {
     const authorDestination = {
-      page: {
-        id: "2"
-      }
+      pageId: "2"
     };
     expect(translateRoutingDestination(authorDestination)).toMatchObject({
       block: "block2"
@@ -14,9 +12,7 @@ describe("Translation of a routing destination", () => {
   });
   it("should translate an absolute destination to another Section", () => {
     const authorDestination = {
-      section: {
-        id: "2"
-      }
+      sectionId: "2"
     };
     expect(translateRoutingDestination(authorDestination)).toMatchObject({
       group: "group2"

--- a/src/eq_schema/schema/Answer/index.js
+++ b/src/eq_schema/schema/Answer/index.js
@@ -45,7 +45,7 @@ class Answer {
     }
 
     if (answer.type === TEXTAREA) {
-      if (this.maxLength) {
+      if (answer.properties.maxLength) {
         this.max_length = parseInt(answer.properties.maxLength);
       }
     }

--- a/src/eq_schema/schema/Answer/index.js
+++ b/src/eq_schema/schema/Answer/index.js
@@ -45,7 +45,9 @@ class Answer {
     }
 
     if (answer.type === TEXTAREA) {
-      this.max_length = parseInt(answer.properties.maxLength);
+      if (this.maxLength) {
+        this.max_length = parseInt(answer.properties.maxLength);
+      }
     }
 
     if (!isNil(answer.validation)) {

--- a/src/eq_schema/schema/Answer/index.test.js
+++ b/src/eq_schema/schema/Answer/index.test.js
@@ -129,8 +129,16 @@ describe("Answer", () => {
         }
       })
     );
-
     expect(answer.max_length).toBe(64);
+  });
+
+  it("should not set maxLength property for textarea types if undefined", () => {
+    const answer = new Answer(
+      createAnswerJSON({
+        type: TEXTAREA
+      })
+    );
+    expect(answer.max_length).toBeUndefined();
   });
 
   describe("validation", () => {

--- a/src/eq_schema/schema/Block/index.js
+++ b/src/eq_schema/schema/Block/index.js
@@ -46,9 +46,11 @@ class Block {
       id: `group${groupId}-introduction`,
       content: {
         title: processPipedTitle(ctx)(introductionTitle) || "",
-        contents: [{
-          description: processPipedText(ctx)(introductionContent) || ""
-        }]
+        contents: [
+          {
+            description: processPipedText(ctx)(introductionContent) || ""
+          }
+        ]
       }
     };
   }
@@ -61,12 +63,27 @@ class Block {
       this.question = new Question(page, ctx);
     }
     if (page.pageType === "CalculatedSummaryPage") {
-      this.title = processPipedTitle(ctx)(page.title)
+      // this.title = [
+      //   {
+      //     value: processPipedTitle(ctx)(page.title)
+      //   }
+      // ];
+      this.title = processPipedTitle(ctx)(page.title);
+
       this.type = "CalculatedSummary";
       this.calculation = {
         calculation_type: "sum",
-        answers_to_calculate: page.summaryAnswers.map(o => `answer${o.id}`),
-        title: processPipedTitle(ctx)(page.totalTitle)
+        answers_to_calculate: page.summaryAnswers.map(o => {
+          console.log("o - - - -  ", o);
+          return `answer${o}`;
+        }),
+        title: processPipedTitle(ctx)(page.title)
+
+        // title: [
+        //   {
+        //     value: processPipedTitle(ctx)(page.totalTitle)
+        //   }
+        // ]
       };
     }
   }

--- a/src/eq_schema/schema/Block/index.js
+++ b/src/eq_schema/schema/Block/index.js
@@ -68,7 +68,7 @@ class Block {
       this.type = "CalculatedSummary";
       this.calculation = {
         calculation_type: "sum",
-        answers_to_calculate: page.summaryAnswers.map(o => `answer${o.id}`),
+        answers_to_calculate: page.summaryAnswers.map(o => `answer${o}`),
         title: processPipedTitle(ctx)(page.totaltitle)
       };
     }

--- a/src/eq_schema/schema/Block/index.js
+++ b/src/eq_schema/schema/Block/index.js
@@ -68,7 +68,7 @@ class Block {
       this.type = "CalculatedSummary";
       this.calculation = {
         calculation_type: "sum",
-        answers_to_calculate: page.summaryAnswers.map(o => `answer${o.id}`),
+        answers_to_calculate: page.summaryAnswers.map(o => `answer${o}`),
         title: processPipedTitle(ctx)(page.totalTitle)
       };
     }

--- a/src/eq_schema/schema/Block/index.js
+++ b/src/eq_schema/schema/Block/index.js
@@ -63,27 +63,13 @@ class Block {
       this.question = new Question(page, ctx);
     }
     if (page.pageType === "CalculatedSummaryPage") {
-      // this.title = [
-      //   {
-      //     value: processPipedTitle(ctx)(page.title)
-      //   }
-      // ];
       this.title = processPipedTitle(ctx)(page.title);
 
       this.type = "CalculatedSummary";
       this.calculation = {
         calculation_type: "sum",
-        answers_to_calculate: page.summaryAnswers.map(o => {
-          console.log("o - - - -  ", o);
-          return `answer${o}`;
-        }),
-        title: processPipedTitle(ctx)(page.title)
-
-        // title: [
-        //   {
-        //     value: processPipedTitle(ctx)(page.totalTitle)
-        //   }
-        // ]
+        answers_to_calculate: page.summaryAnswers.map(o => `answer${o.id}`),
+        title: processPipedTitle(ctx)(page.totaltitle)
       };
     }
   }

--- a/src/eq_schema/schema/Block/index.js
+++ b/src/eq_schema/schema/Block/index.js
@@ -61,20 +61,12 @@ class Block {
       this.question = new Question(page, ctx);
     }
     if (page.pageType === "CalculatedSummaryPage") {
-      this.titles = [
-        {
-          value: processPipedTitle(ctx)(page.title)
-        }
-      ];
+      this.title = processPipedTitle(ctx)(page.title)
       this.type = "CalculatedSummary";
       this.calculation = {
         calculation_type: "sum",
         answers_to_calculate: page.summaryAnswers.map(o => `answer${o.id}`),
-        titles: [
-          {
-            value: processPipedTitle(ctx)(page.totalTitle)
-          }
-        ]
+        title: processPipedTitle(ctx)(page.totalTitle)
       };
     }
   }

--- a/src/eq_schema/schema/Block/index.js
+++ b/src/eq_schema/schema/Block/index.js
@@ -68,8 +68,8 @@ class Block {
       this.type = "CalculatedSummary";
       this.calculation = {
         calculation_type: "sum",
-        answers_to_calculate: page.summaryAnswers.map(o => `answer${o}`),
-        title: processPipedTitle(ctx)(page.totaltitle)
+        answers_to_calculate: page.summaryAnswers.map(o => `answer${o.id}`),
+        title: processPipedTitle(ctx)(page.totalTitle)
       };
     }
   }

--- a/src/eq_schema/schema/Block/index.test.js
+++ b/src/eq_schema/schema/Block/index.test.js
@@ -168,10 +168,10 @@ describe("Block", () => {
         calculation: {
           answers_to_calculate: ["answer1", "answer2", "answer3"],
           calculation_type: "sum",
-          titles: [{ value: "Bye" }]
+          title: "Bye"
         },
         // id: "block1",
-        titles: [{ value: "Hi is your total %(total)s" }],
+        title: "Hi is your total %(total)s",
         type: "CalculatedSummary"
       });
     });

--- a/src/eq_schema/schema/Block/index.test.js
+++ b/src/eq_schema/schema/Block/index.test.js
@@ -151,17 +151,7 @@ describe("Block", () => {
           '<p>Hi is your total <span data-piped="variable"data-id="1">[Total]</span></p>',
         pageType: "CalculatedSummaryPage",
         totalTitle: "<p>Bye</p>",
-        summaryAnswers: [
-          {
-            id: "1"
-          },
-          {
-            id: "2"
-          },
-          {
-            id: "3"
-          }
-        ]
+        summaryAnswers: ["1","2","3",]
       };
       const block = new Block(calculatedPageGraphql, ctx);
       expect(block).toMatchObject({

--- a/src/eq_schema/schema/Group/index.test.js
+++ b/src/eq_schema/schema/Group/index.test.js
@@ -330,8 +330,8 @@ describe("Group", () => {
                 {
                   id:
                     "answerconfirmation-answer-for-uu1d-iuhiuwfew-fewfewfewdsf-dsf-1",
-                  condition: "contains any",
-                  values: ["Wait I can get more?"]
+                  condition: "equals",
+                  value: "Wait I can get more?"
                 }
               ]
             }
@@ -392,8 +392,8 @@ describe("Group", () => {
                 {
                   id:
                     "answerconfirmation-answer-for-uu1d-iuhiuwfew-fewfewfewdsf-dsf-1",
-                  condition: "contains any",
-                  values: ["Wait I can get more?"]
+                  condition: "equals",
+                  value: "Wait I can get more?"
                 }
               ]
             }
@@ -418,30 +418,20 @@ describe("Group", () => {
               expressions: [
                 {
                   left: {
-                    id: "1",
-                    type: "Radio",
-                    options: [
-                      {
-                        id: "1"
-                      }
-                    ]
+                    answerId: "1",
+                    type: "Answer",
                   },
-                  condition: "OneOf",
+                  condition: "Equal",
                   right: {
-                    options: [
-                      {
-                        id: "1",
-                        label: "2.3"
-                      }
-                    ]
+                    customValue: {
+                      number: "5"
+                    }
                   }
                 }
               ]
             },
             destination: {
-              section: {
-                id: "2"
-              },
+              sectionId: "2",
               page: null,
               logical: null
             }
@@ -470,8 +460,8 @@ describe("Group", () => {
               {
                 id:
                   "answerconfirmation-answer-for-uu1d-iuhiuwfew-fewfewfewdsf-dsf-1",
-                condition: "contains any",
-                values: ["Wait I can get more?"]
+                condition: "equals",
+                value: "Wait I can get more?"
               }
             ]
           }
@@ -482,8 +472,8 @@ describe("Group", () => {
             when: [
               {
                 id: "answer1",
-                condition: "contains any",
-                values: ["2.3"]
+                condition: "equals",
+                value: "5"
               }
             ]
           }

--- a/src/eq_schema/schema/Question/index.js
+++ b/src/eq_schema/schema/Question/index.js
@@ -3,6 +3,7 @@ const { set } = require("lodash");
 
 const {
   parseContent,
+  parseContents,
   getInnerHTMLWithPiping,
   unescapePiping
 } = require("../../../utils/HTMLUtils");
@@ -21,6 +22,7 @@ const findMutuallyExclusive = flow(
 const processPipedText = ctx => flow(convertPipes(ctx), getInnerHTMLWithPiping);
 
 const processContent = ctx => flow(convertPipes(ctx), parseContent);
+const processContents = ctx => flow(convertPipes(ctx), parseContents);
 
 class Question {
   constructor(question, ctx) {
@@ -37,7 +39,7 @@ class Question {
     }
 
     if (question.guidanceEnabled && question.guidance) {
-      this.guidance = processContent(ctx)(question.guidance);
+      this.guidance = processContents(ctx)(question.guidance);
     }
 
     if (
@@ -47,7 +49,7 @@ class Question {
       this.definitions = [
         {
           title: question.definitionLabel,
-          ...processContent(ctx)(question.definitionContent)
+          ...processContents(ctx)(question.definitionContent)
         }
       ];
     }

--- a/src/eq_schema/schema/Question/index.js
+++ b/src/eq_schema/schema/Question/index.js
@@ -3,7 +3,6 @@ const { set } = require("lodash");
 
 const {
   parseContent,
-  parseContents,
   getInnerHTMLWithPiping,
   unescapePiping
 } = require("../../../utils/HTMLUtils");
@@ -22,7 +21,6 @@ const findMutuallyExclusive = flow(
 const processPipedText = ctx => flow(convertPipes(ctx), getInnerHTMLWithPiping);
 
 const processContent = ctx => flow(convertPipes(ctx), parseContent);
-const processContents = ctx => flow(convertPipes(ctx), parseContents);
 
 class Question {
   constructor(question, ctx) {
@@ -39,7 +37,7 @@ class Question {
     }
 
     if (question.guidanceEnabled && question.guidance) {
-      this.guidance = processContents(ctx)(question.guidance);
+      this.guidance = processContent(ctx)(question.guidance)("contents");
     }
 
     if (
@@ -49,7 +47,7 @@ class Question {
       this.definitions = [
         {
           title: question.definitionLabel,
-          ...processContents(ctx)(question.definitionContent)
+          ...processContent(ctx)(question.definitionContent)("contents")
         }
       ];
     }
@@ -115,7 +113,8 @@ class Question {
       last(this.answers).guidance = {
         show_guidance: question.additionalInfoLabel,
         hide_guidance: question.additionalInfoLabel,
-        ...processContent(ctx)(question.additionalInfoContent)
+
+        ...processContent(ctx)(question.additionalInfoContent)("content")
       };
     }
   }
@@ -133,7 +132,7 @@ class Question {
     const dateFrom = {
       ...commonAnswerDef,
       id: `${commonAnswerDef.id}from`,
-      label: answer.label,
+      label: answer.label
     };
     if (answer.qCode) {
       dateFrom.q_code = answer.qCode;
@@ -141,7 +140,7 @@ class Question {
     const dateTo = {
       ...commonAnswerDef,
       id: `${commonAnswerDef.id}to`,
-      label: answer.secondaryLabel,
+      label: answer.secondaryLabel
     };
     if (answer.secondaryQCode) {
       dateTo.q_code = answer.secondaryQCode;

--- a/src/eq_schema/schema/Question/index.test.js
+++ b/src/eq_schema/schema/Question/index.test.js
@@ -474,10 +474,10 @@ describe("Question", () => {
           ]
         }
       ];
-      answers[0].validation.earliestDate.enabled = false
-      answers[0].validation.latestDate.enabled = false
-      answers[0].validation.minDuration.enabled = false
-      answers[0].validation.maxDuration.enabled = false
+      answers[0].validation.earliestDate.enabled = false;
+      answers[0].validation.latestDate.enabled = false;
+      answers[0].validation.minDuration.enabled = false;
+      answers[0].validation.maxDuration.enabled = false;
       const question = new Question(createQuestionJSON({ answers }));
 
       expect(question.answers[0]).toEqual(
@@ -516,7 +516,7 @@ describe("Question", () => {
       );
     });
 
-    it("should create date with qcodes", () => {
+    it("should create date with qCodes", () => {
       const answers = [
         {
           type: DATE_RANGE,
@@ -544,8 +544,6 @@ describe("Question", () => {
         })
       );
     });
-
-
   });
 
   describe("piping", () => {
@@ -580,8 +578,7 @@ describe("Question", () => {
         }),
         createContext()
       );
-
-      expect(question.guidance.content[0]).toEqual({
+      expect(question.guidance.contents[0]).toEqual({
         title: "{{ metadata['my_metadata'] }}"
       });
     });
@@ -865,7 +862,7 @@ describe("Question", () => {
       });
     });
 
-    it("should set the custom value when the entiyType is Custom", () => {
+    it("should set the custom value when the entityType is Custom", () => {
       validation.entityType = "Custom";
       validation.custom = 10;
       validation.previousAnswer = { id: 20 };

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ dotenv.config();
 const logger = pino();
 const app = express();
 
-app.use(bodyParser.json({limit: '10mb', extended: true}));
+app.use(bodyParser.json({ limit: "10mb", extended: true }));
 app.use(
   helmet({
     referrerPolicy: {

--- a/src/middleware/validation/index.js
+++ b/src/middleware/validation/index.js
@@ -8,7 +8,6 @@ const validation = async (req, res, next) => {
   if (!(Object.entries(result).length === 0)) {
     return res.status(400).send(result);
   }
-  console.log("success - - - = - - -");
   next();
 };
 

--- a/src/middleware/validation/index.js
+++ b/src/middleware/validation/index.js
@@ -5,9 +5,10 @@ const validation = async (req, res, next) => {
   const api = new ApiValidator(process.env.EQ_VALIDATOR_URL);
   const validator = new SchemaValidator(api);
   const result = await validator.validate(res.locals.questionnaire);
-  if (!result.valid) {
+  if (!(Object.entries(result).length === 0)) {
     return res.status(400).send(result);
   }
+  console.log("success - - - = - - -");
   next();
 };
 

--- a/src/utils/HTMLUtils/index.js
+++ b/src/utils/HTMLUtils/index.js
@@ -39,7 +39,7 @@ const mapElementToObject = elem => {
   }
 };
 
-const parseContent = html => {
+const parseContent = html => propertyName => {
   const content = cheerio(html)
     .filter((i, elem) => getInnerHTML(elem) !== "")
     .map((i, elem) => mapElementToObject(elem))
@@ -49,27 +49,13 @@ const parseContent = html => {
     return;
   }
 
-  return { content };
-};
-
-const parseContents = html => {
-  const contents = cheerio(html)
-    .filter((i, elem) => getInnerHTML(elem) !== "")
-    .map((i, elem) => mapElementToObject(elem))
-    .toArray();
-
-  if (contents.length === 0) {
-    return;
-  }
-
-  return { contents };
+  return { [propertyName]: content };
 };
 
 module.exports = {
   getInnerHTML,
   getText,
   parseContent,
-  parseContents,
   getInnerHTMLWithPiping,
   unescapePiping
 };

--- a/src/utils/HTMLUtils/index.js
+++ b/src/utils/HTMLUtils/index.js
@@ -52,10 +52,24 @@ const parseContent = html => {
   return { content };
 };
 
+const parseContents = html => {
+  const contents = cheerio(html)
+    .filter((i, elem) => getInnerHTML(elem) !== "")
+    .map((i, elem) => mapElementToObject(elem))
+    .toArray();
+
+  if (contents.length === 0) {
+    return;
+  }
+
+  return { contents };
+};
+
 module.exports = {
   getInnerHTML,
   getText,
   parseContent,
+  parseContents,
   getInnerHTMLWithPiping,
   unescapePiping
 };

--- a/src/utils/HTMLUtils/index.test.js
+++ b/src/utils/HTMLUtils/index.test.js
@@ -23,9 +23,9 @@ describe("HTMLUtils", () => {
 
   describe("parseContent", () => {
     it("should return undefined if no content supplied", () => {
-      expect(parseContent()).toBeUndefined();
-      expect(parseContent("")).toBeUndefined();
-      expect(parseContent("<p></p>")).toBeUndefined();
+      expect(parseContent()("content")).toBeUndefined();
+      expect(parseContent("")("content")).toBeUndefined();
+      expect(parseContent("<p></p>")("content")).toBeUndefined();
     });
 
     it("should correctly parse content into runner-compatible object", () => {
@@ -42,7 +42,7 @@ describe("HTMLUtils", () => {
         </ul>
       `;
 
-      expect(parseContent(guidance)).toEqual({
+      expect(parseContent(guidance)("content")).toEqual({
         content: [
           {
             title: "Vivamus sagittis lacus vel augue laoreet"

--- a/src/utils/convertRoutingConditions/index.js
+++ b/src/utils/convertRoutingConditions/index.js
@@ -7,7 +7,8 @@ const routingConditionConversions = {
   LessOrEqual: "less than or equal to",
   AllOf: "contains all",
   AnyOf: "contains any",
-  Unanswered: "not set"
+  Unanswered: "not set",
+  OneOf: "contains any"
 };
 
 const conditionConversion = authorCondition => {


### PR DESCRIPTION
## What we did
This includes changes made to v2 publisher to check against maxLength

V3 schema to check if curious can be found: 
https://github.com/ONSdigital/eq-questionnaire-validator/tree/master/schemas

Schema changes include:
- Calc sum properties from **titles** to **title**
- Title no longer kept in the array

## To test in POSTMAN
* [ ] Build an eq-author questionnaire with a calculated summary and confirmation question
* [ ] Spin up eq-author-publisher using docker-compose
**Might require closing down publisher-v3 or setting the PORT to 9001 for publisher-v3**
* [ ] Collect eq-author JSON from `/graphql` endpoint in publisher
**Author JSON needs to come from `/graphql`. This endpoint modifies the JSON slightly**
**Example:** `localhost:9000/graphql/:questionnaireId`

**In Postman**
* [ ] Set to POST query and use local `/publish` endpoint
* [ ] Add author JSON to body with raw and type of JSON (text by default)
* [ ] Hit send
* [ ] Postman should return converted JSON

* [ ] Repeat above steps using `/publish/validate` to check if the schema is valid
* [ ] If there are no errors returned, the schema is valid

Things to check:
* [ ] All tests pass
* [ ] 100% code coverage using `yarn jest --coverage`
* [ ] Questionnaires with confirmation question and calc sum should return no validation errors
* [ ] Calculated summary `summaryAnswers` should match `answer[A-z0-9]+` in converted JSON
* [ ] Calculated summary should have **title** property in converted JSON