### PR TITLE
Yarn start now works as expected

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "start": "node ./src",
+    "start": "node ./src/server.js",
     "develop": "nodemon yarn start",
     "lint": "eslint .",
     "test": "jest --watch",


### PR DESCRIPTION
`yarn start` does not work as the command ran by it, `node ./src` cannot find an `index.js` to run

I have fixed this by pointing it at `./src/server.js` instead.