### PR TITLE
EAR 971 - Add support for collapsible summary toggle to publisher v3

### DIFF
--- a/src/eq_schema/block-types/Summary/index.js
+++ b/src/eq_schema/block-types/Summary/index.js
@@ -1,13 +1,15 @@
 class Summary {
-  constructor() {
+  constructor({collapsible}) {
     this.id = "summary-group";
     this.title = "Summary";
-    this.blocks = [
-      {
+    const summaryBlock = {
         type: "Summary",
         id: "summary-block"
-      }
-    ];
+    };
+    if(collapsible) {
+      summaryBlock.collapsible = true;
+    }
+    this.blocks = [summaryBlock];
   }
 }
 

--- a/src/eq_schema/block-types/Summary/index.test.js
+++ b/src/eq_schema/block-types/Summary/index.test.js
@@ -1,8 +1,8 @@
 const Summary = require(".");
 
 describe("Summary", () => {
-  it("should build valid runner Summary", () => {
-    const summary = new Summary();
+  it("should build valid runner Summary - non collapsible sections", () => {
+    const summary = new Summary({collapsible: false});
     expect(summary).toEqual({
       id: "summary-group",
       title: "Summary",
@@ -10,6 +10,20 @@ describe("Summary", () => {
         {
           type: "Summary",
           id: "summary-block"
+        }
+      ]
+    });
+  });
+  it("should build valid runner Summary - collapsible sections", () => {
+    const summary = new Summary({collapsible: true});
+    expect(summary).toEqual({
+      id: "summary-group",
+      title: "Summary",
+      blocks: [
+        {
+          type: "Summary",
+          id: "summary-block",
+          collapsible: true
         }
       ]
     });

--- a/src/eq_schema/schema/Questionnaire/index.js
+++ b/src/eq_schema/schema/Questionnaire/index.js
@@ -50,7 +50,7 @@ class Questionnaire {
       duration: 900
     };
 
-    this.buildSummaryOrConfirmation(questionnaireJson.summary);
+    this.buildSummaryOrConfirmation(questionnaireJson.summary, questionnaireJson.collapsibleSummary);
   }
 
   buildSurveyId(publishDetails, title) {
@@ -79,8 +79,8 @@ class Questionnaire {
     return sections.map(section => new Section(section, ctx));
   }
 
-  buildSummaryOrConfirmation(summary) {
-    const finalPage = summary ? new Summary() : new Confirmation();
+  buildSummaryOrConfirmation(summary, collapsible) {
+    const finalPage = summary ? new Summary({collapsible}) : new Confirmation();
     last(this.sections).groups.push(finalPage);
   }
 


### PR DESCRIPTION
### What is the context of this PR?

This PR adds support for the collapsible summary toggle introduced as part of EAR 971 to publisher v3.
[See the request adding feature to eq-author repo for more detail.](https://github.com/ONSdigital/eq-author-app/pull/1573)

### How to review

- Create a questionnaire & set the "collapsible summary" toggle to `On`.
- Export the questionnaire's JSON from Author and post it to Publisher v3.
- Check that the `summary-block` block has `collapsible` set to `true`.

- Toggle the "collapsible summary" toggle to `Off`.
- Export the questionnaire's JSON from Author and post it to Publisher v3.
- Check that the `summary-block` block has no `collapsible` attribute.