### PR TITLE
EAR 902 - Folders - Add basic folder support to v3

### DIFF
--- a/src/eq_schema/schema/Questionnaire/index.test.js
+++ b/src/eq_schema/schema/Questionnaire/index.test.js
@@ -27,7 +27,12 @@ describe("Questionnaire", () => {
           {
             id: "1",
             title: "Section",
-            pages: []
+            folders: [
+              {
+                id: "f1",
+                pages: [],
+              }
+            ],
           }
         ],
         metadata: [],
@@ -110,14 +115,24 @@ describe("Questionnaire", () => {
           {
             id: "2",
             title: "Section number 2",
-            pages: []
+            folders: [
+              {
+                id: "f1",
+                pages: [],
+              },
+            ],
           },
           {
             id: "3",
             title: "Section number 3",
-            pages: []
-          }
-        ]
+            folders: [
+              {
+                id: "f2",
+                pages: [],
+              },
+            ],
+          },
+        ],
       })
     );
 
@@ -144,16 +159,27 @@ describe("Questionnaire", () => {
           {
             id: "2",
             title: "<p>Section <em>number</em> 2</p>",
-            pages: []
+            folders: [
+              {
+                id: "f1",
+                pages: [],
+              },
+            ],
           },
           {
             id: "3",
             title: "<p>Section <em>number</em> 3</p>",
-            pages: []
-          }
-        ]
+            folders: [
+              {
+                id: "f2",
+                pages: [],
+              },
+            ],
+          },
+        ],
       })
     );
+
 
     expect(questionnaire).toMatchObject({
       sections: [

--- a/src/eq_schema/schema/Section/index.js
+++ b/src/eq_schema/schema/Section/index.js
@@ -1,6 +1,25 @@
+const Group = require("../Group");
 const { getText } = require("../../../utils/HTMLUtils");
 
-const Group = require("../Group");
+const mergeDisabledFolders = oldFolders => {
+  const folders = [...oldFolders];
+  const newFolders = [folders.pop()];
+
+  folders.forEach(folder => {
+    if (folder.enabled) {
+      newFolders.push(folder);
+    } else {
+      const lastMergedFolder = newFolders[newFolders.length - 1];
+      if (lastMergedFolder.enabled) {
+        newFolders.push(folder);
+      } else {
+        lastMergedFolder.pages.push(...folder.pages);
+      }
+    }
+  });
+
+  return newFolders;
+};
 
 class Section {
   constructor(section, ctx) {
@@ -9,12 +28,11 @@ class Section {
       this.title = getText(section.title);
     }
 
-    this.groups = this.buildGroups(section, ctx);
-  }
-
-  buildGroups(section, ctx) {
-    // Sections always contain a single group currently
-    return [new Group(getText(section.title), section, ctx)];
+    // Map folders to eq-runner "groups"
+    // No need to make a group for each; we merge disabled (hidden) folders together where possible
+    this.groups = mergeDisabledFolders(section.folders).map(
+      folder => new Group(getText(section.title), folder, ctx)
+    );
   }
 }
 

--- a/src/eq_schema/schema/Section/index.test.js
+++ b/src/eq_schema/schema/Section/index.test.js
@@ -7,19 +7,25 @@ describe("Section", () => {
       {
         id: "1",
         title: "Section 1",
-        pages: [
+        folders: [
           {
-            id: "2",
-            answers: []
-          }
-        ]
+            id: "f1",
+            enabled: false,
+            pages: [
+              {
+                id: "2",
+                answers: [],
+              },
+            ],
+          },
+        ],
       },
       options
     );
   const createCtx = (options = {}) => ({
     routingGotos: [],
     questionnaireJson: { navigation: true },
-    ...options
+    ...options,
   });
 
   it("should build valid runner Section from Author section", () => {
@@ -30,11 +36,11 @@ describe("Section", () => {
       title: "Section 1",
       groups: [
         {
-          id: "group1",
+          id: "groupf1",
           title: "Section 1",
-          blocks: [expect.any(Block)]
-        }
-      ]
+          blocks: [expect.any(Block)],
+        },
+      ],
     });
   });
 
@@ -48,11 +54,43 @@ describe("Section", () => {
       id: "section1",
       groups: [
         {
-          id: "group1",
+          id: "groupf1",
           title: "",
-          blocks: [expect.any(Block)]
-        }
-      ]
+          blocks: [expect.any(Block)],
+        },
+      ],
+    });
+  });
+
+  describe("mergeDisabledFolders", () => {
+    let sectionJSON;
+    beforeEach(() => {
+      sectionJSON = createSectionJSON();
+    });
+
+    it("should merge consecutive disabled folders together", () => {
+      sectionJSON.folders.push(sectionJSON.folders[0]);
+      const section = new Section(sectionJSON, createCtx());
+
+      expect(section.groups).toHaveLength(1);
+    });
+
+    it("shouldn't merge enabled folders with previous disabled folder", () => {
+      sectionJSON.folders.push({
+        ...sectionJSON.folders[0],
+        enabled: true,
+      });
+      const section = new Section(sectionJSON, createCtx());
+
+      expect(section.groups).toHaveLength(2);
+    });
+
+    it("shouldn't merge disabled folders with previous enabled folder", () => {
+      sectionJSON.folders.push(sectionJSON.folders[0]);
+      sectionJSON.folders[0].enabled = true;
+      const section = new Section(sectionJSON, createCtx());
+
+      expect(section.groups).toHaveLength(2);
     });
   });
 });


### PR DESCRIPTION
Implements fix to allow publisher to work as before with folders in the Author schema.

As with v2, will need further changes once skip conditions implemented for folders.