### PR TITLE
EAR-1398 Merge all folders into group

### DIFF
--- a/src/eq_schema/schema/Group/index.js
+++ b/src/eq_schema/schema/Group/index.js
@@ -1,63 +1,50 @@
 const Block = require("../Block");
-const { isEmpty, reject, flatten, uniqWith, isEqual } = require("lodash");
+const { isEmpty, reject, flatten } = require("lodash");
 const {
   buildAuthorConfirmationQuestion,
 } = require("../../builders/confirmationPage/ConfirmationPage");
-const translateAuthorSkipconditions = require("../../builders/skipConditions");
 
 class Group {
-  constructor(title, folder, ctx) {
-    this.id = `group${folder.id}`;
+  constructor(title, section, ctx) {
+    this.id = `group${section.id}`;
     if (title) {
       this.title = title;
     }
-    this.blocks = this.buildBlocks(folder, ctx);
-
-    this.skip_conditions = [];
-
-    if (folder.skipConditions) {
-      this.skip_conditions.push(
-        ...translateAuthorSkipconditions(folder.skipConditions, ctx)
-      );
-    }
+    this.blocks = this.buildBlocks(section, ctx);
 
     if (!isEmpty(ctx.routingGotos)) {
       this.filterContext(this.id, ctx);
-      const skipConditions = uniqWith(
-        this.buildSkipConditions(this.id, ctx),
-        isEqual
-      );
-      this.skip_conditions.push(...skipConditions);
-    }
+      const skipConditions = this.buildSkipConditions(this.id, ctx);
 
-    if (!this.skip_conditions.length) {
-      delete this.skip_conditions;
+      if (!isEmpty(skipConditions)) {
+        this.skip_conditions = skipConditions;
+      }
     }
   }
 
   filterContext(currentId, ctx) {
     ctx.routingGotos = reject(
       ctx.routingGotos,
-      (rule) => rule.group === currentId
+      rule => rule.group === currentId
     );
   }
 
   buildSkipConditions(currentId, ctx) {
-    return reject(ctx.routingGotos, (goto) => goto.groupId === currentId).map(
+    return reject(ctx.routingGotos, goto => goto.groupId === currentId).map(
       ({ when }) => ({
-        when,
+        when
       })
     );
   }
 
-  buildBlocks(folder, ctx) {
+  buildBlocks(section, ctx) {
     return flatten(
-      folder.pages.map((page) => {
-        const block = new Block(page, folder.id, ctx);
+      section.pages.map((page) => {
+        const block = new Block(page, section.id, ctx);
         if (page.confirmation) {
           return [
             block,
-            buildAuthorConfirmationQuestion(page, folder.id, page.routing, ctx),
+            buildAuthorConfirmationQuestion(page, section.id, page.routing, ctx),
           ];
         }
         return block;

--- a/src/eq_schema/schema/Group/index.test.js
+++ b/src/eq_schema/schema/Group/index.test.js
@@ -109,40 +109,6 @@ describe("Group", () => {
       expect(runnerJson).toMatchObject(expectedrunnerJson);
     });
 
-    it("adds skip conditions when specified for a folder", () => {
-      const ctx = createCtx();
-      const folder = {
-        id: "folder-1",
-        enabled: "true",
-        pages: [],
-        skipConditions: [
-          {
-            expressions: [
-              {
-                left: {
-                  answerId: "1",
-                  type: "Answer",
-                },
-                condition: "Equal",
-                right: {
-                  type: "Custom",
-                  customValue: {
-                    number: 1337,
-                  },
-                },
-              },
-            ],
-          },
-        ],
-      };
-
-      const group = new Group(null, folder, ctx);
-
-      expect(group.skip_conditions[0]).toMatchObject({
-        when: [{ id: "answer1", condition: "equals", value: 1337 }],
-      });
-    });
-
     it("can handle multiple skip conditions for each group", () => {
       const groupsJson = createGroupsJSON();
 

--- a/src/eq_schema/schema/Section/index.test.js
+++ b/src/eq_schema/schema/Section/index.test.js
@@ -35,7 +35,7 @@ describe("Section", () => {
       title: "Section 1",
       groups: [
         {
-          id: "groupfolder-1",
+          id: "group1",
           blocks: [expect.any(Block)]
         }
       ]
@@ -52,42 +52,10 @@ describe("Section", () => {
       id: "section1",
       groups: [
         {
-          id: "groupfolder-1",
+          id: "group1",
           blocks: [expect.any(Block)]
         }
       ]
-    });
-  });
-
-  describe("mergeDisabledFolders", () => {
-    let sectionJSON;
-    beforeEach(() => {
-      sectionJSON = createSectionJSON();
-    });
-
-    it("should merge consecutive disabled folders together", () => {
-      sectionJSON.folders.push(sectionJSON.folders[0]);
-      const section = new Section(sectionJSON, createCtx());
-
-      expect(section.groups).toHaveLength(1);
-    });
-
-    it("shouldn't merge enabled folders with previous disabled folder", () => {
-      sectionJSON.folders.push({
-        ...sectionJSON.folders[0],
-        enabled: true,
-      });
-      const section = new Section(sectionJSON, createCtx());
-
-      expect(section.groups).toHaveLength(2);
-    });
-
-    it("shouldn't merge disabled folders with previous enabled folder", () => {
-      sectionJSON.folders.push({ ...sectionJSON.folders[0] });
-      sectionJSON.folders[0].enabled = true;
-      const section = new Section(sectionJSON, createCtx());
-
-      expect(section.groups).toHaveLength(2);
     });
   });
 


### PR DESCRIPTION
This updates implements the v2 change that merges all the folders into a single group in a section.
To test.
Create a schema with questions and folders with skips on them in a single section.

Test that schema in postman and review the output.
You are looking to see that all folders are reduced into a single group and any skip conditions added to the questions where appropriate.

https://collaborate2.ons.gov.uk/jira/browse/EAR-1398