### PR TITLE
Ear 1537

### DIFF
--- a/src/eq_schema/schema/Answer/index.js
+++ b/src/eq_schema/schema/Answer/index.js
@@ -215,7 +215,6 @@ class Answer {
         ...pick(additionalAnswer, ["label", "type"]),
         id: `answer${additionalAnswer.id}`,
         mandatory: properties.required,
-        q_code: additionalAnswer.qCode,
       };
 
       if (additionalAnswer.qCode && type !== "Checkbox") {


### PR DESCRIPTION
Context of PR
Fix to the duplication bug caused by having a qCode for the Checkbox Other Label. Fix to the v3 version of publisher to bring them in line and up to date.

How to review
Create a questionnaire with Radio and Checkbox Other Options.
Check that now, in the qCode table, there's no option to add a qCode for Checkbox Other Labels.
Check the publisher JSON, and now in Detail_Answer in the schema. Only Radio will have a qCode and checkbox will have no qCode.
What to do after everything is green
*   Bring this branch up-to-date with Origin/Master
*   If there are a lot of commits or some are not helpful to read, squash them down
*   Click the Merge button on this pull request
*   Does this change mean the Capability examples questionnaire should be updated?
*   Move the Jira ticket for this task into the next stage of the process