### PR TITLE
fix for text starting with link

### DIFF
--- a/src/utils/HTMLUtils/index.js
+++ b/src/utils/HTMLUtils/index.js
@@ -4,7 +4,9 @@ const { replace } = require("lodash/fp");
 
 const isPlainText = elem => typeof elem === "string" && !elem.startsWith("<");
 
-const getInnerHTML = elem => (isPlainText(elem) ? elem : cheerio(elem).html());
+const startsWithLink = elem => typeof elem === "string" && elem.startsWith("<a");
+
+const getInnerHTML = elem => (isPlainText(elem) || startsWithLink(elem) ) ? elem : cheerio(elem).html();
 
 const removeDash = elem => replace(/-/g, "_", elem);
 


### PR DESCRIPTION
Currently if text starts with a hyper link it gets parsed to plain text. 

Updated to stop that.