### PR TITLE
Ear 1652 publisher not creating total validation

### DIFF
--- a/src/eq_schema/schema/Question/index.js
+++ b/src/eq_schema/schema/Question/index.js
@@ -189,13 +189,6 @@ class Question {
         ? { value: totalValidation.custom }
         : { answer_id: `answer${totalValidation.previousAnswer}` };
 
-    console.log("boom", {
-      calculation_type: "sum",
-      answers_to_calculate: answers.map((a) => `answer${a.id}`),
-      conditions: AUTHOR_TO_RUNNER_CONDITIONS[totalValidation.condition],
-      ...rightSide,
-    });
-
     return {
       calculation_type: "sum",
       answers_to_calculate: answers.map((a) => `answer${a.id}`),

--- a/src/eq_schema/schema/Question/index.js
+++ b/src/eq_schema/schema/Question/index.js
@@ -187,7 +187,14 @@ class Question {
     const rightSide =
       totalValidation.entityType === "Custom"
         ? { value: totalValidation.custom }
-        : { answer_id: `answer${totalValidation.previousAnswer.id}` };
+        : { answer_id: `answer${totalValidation.previousAnswer}` };
+
+    console.log("boom", {
+      calculation_type: "sum",
+      answers_to_calculate: answers.map((a) => `answer${a.id}`),
+      conditions: AUTHOR_TO_RUNNER_CONDITIONS[totalValidation.condition],
+      ...rightSide,
+    });
 
     return {
       calculation_type: "sum",

--- a/src/eq_schema/schema/Question/index.test.js
+++ b/src/eq_schema/schema/Question/index.test.js
@@ -650,15 +650,15 @@ describe("Question", () => {
             },
             {
               id: "2",
-              label: "Option 2"
+              label: "Option 2",
             },
             {
               id: "3",
               label: "Mutually exclusive",
               mutuallyExclusive: true,
-            }
-          ]
-        }
+            },
+          ],
+        },
       ];
     });
 
@@ -670,11 +670,11 @@ describe("Question", () => {
     });
 
     it("should have a question type of general when no mutually exclusive option", () => {
-      const newAnswers = cloneDeep(answers) 
-      remove(newAnswers[0].options, {mutuallyExclusive: true})
+      const newAnswers = cloneDeep(answers);
+      remove(newAnswers[0].options, { mutuallyExclusive: true });
       const question = new Question(
         createQuestionJSON({
-          answers: newAnswers
+          answers: newAnswers,
         })
       );
       expect(question).toMatchObject({
@@ -871,12 +871,13 @@ describe("Question", () => {
     it("should set the answer_id to the previous answer when entityType is PreviousAnswer", () => {
       validation.entityType = "PreviousAnswer";
       validation.custom = 10;
-      validation.previousAnswer = { id: 20 };
+      validation.previousAnswer = 20;
       const question = new Question(
         createQuestionJSON({
           totalValidation: validation,
         })
       );
+
       expect(question.calculations[0].value).not.toBeDefined();
       expect(question.calculations[0].answer_id).toEqual("answer20");
     });


### PR DESCRIPTION
### Context of PR ###
When adding a Total Number validation and referencing a previous question, in the Publisher Schema the ID of the previous question is undefined.

https://collaborate2.ons.gov.uk/jira/secure/RapidBoard.jspa?rapidView=940&projectKey=EAR&view=detail&selectedIssue=EAR-1652

### How to review ###
- [ ] Create  two number answers where the Total Number Validation is equal to a `Previous Answer`.
- [ ] Check the schema of Publisher and check in the calculations array of that question, that `answer_id` is not undefined, but equal to the id of the answer you're referencing.

### What to do after everything is green ###

    *  Bring this branch up-to-date with Origin/Master
    *  If there are a lot of commits or some are not helpful to read, squash them down
    *  Click the Merge button on this pull request
    *  Does this change mean the Capability examples questionnaire should be updated?
    *  Move the Jira ticket for this task into the next stage of the process
