### PR TITLE
fix for section title not showing

### DIFF
--- a/src/eq_schema/schema/Section/index.js
+++ b/src/eq_schema/schema/Section/index.js
@@ -6,7 +6,7 @@ const translateDisplayConditions = require("../../builders/expressionGroup");
 class Section {
   constructor(section, ctx) {
     this.id = `section${section.id}`;
-    if (ctx.questionnaireJson.navigation || ctx.questionnaireJson.hub) {
+    if (section.title) {
       this.title = getText(section.title);
     }
     if ("showOnHub" in section) {


### PR DESCRIPTION
To reproduce
In a linear survey, enable section summary and add a section title

In runner the title will not show on the summary page