### PR TITLE
EAR-1681-Add previous link to forst question if hub is false

### DIFF
--- a/src/eq_schema/schema/Questionnaire/index.js
+++ b/src/eq_schema/schema/Questionnaire/index.js
@@ -53,7 +53,7 @@ class Questionnaire {
 
     this.sections = this.buildSections(questionnaireJson.sections, ctx);
 
-    if (ctx.hub) {
+    if (questionnaireJson.hub) {
       this.buildIntroduction(questionnaireJson.introduction, ctx);
     } else {
       this.buildIntroductionInsideFirstSection(

--- a/src/eq_schema/schema/Questionnaire/index.js
+++ b/src/eq_schema/schema/Questionnaire/index.js
@@ -1,6 +1,6 @@
 const {
   DEFAULT_METADATA,
-  DEFAULT_METADATA_NAMES
+  DEFAULT_METADATA_NAMES,
 } = require("../../../constants/metadata");
 
 const { contentMap } = require("../../../constants/legalBases");
@@ -17,9 +17,9 @@ const Submission = require("../Submission");
 const QuestionnaireFlow = require("../QuestionnaireFlow");
 
 const getPreviewTheme = ({ previewTheme, themes }) =>
-  themes && themes.find(theme => theme && theme.shortName === previewTheme);
+  themes && themes.find((theme) => theme && theme.shortName === previewTheme);
 
-const getTheme = previewTheme => {
+const getTheme = (previewTheme) => {
   if (validThemes.includes(previewTheme)) {
     return previewTheme;
   } else {
@@ -53,12 +53,19 @@ class Questionnaire {
 
     this.sections = this.buildSections(questionnaireJson.sections, ctx);
 
-    this.buildIntroduction(questionnaireJson.introduction, ctx);
+    if (ctx.hub) {
+      this.buildIntroduction(questionnaireJson.introduction, ctx);
+    } else {
+      this.buildIntroductionInsideFirstSection(
+        questionnaireJson.introduction,
+        ctx
+      );
+    }
 
     this.theme = getTheme(questionnaireJson.themeSettings.previewTheme);
 
     this.navigation = {
-      visible: questionnaireJson.navigation
+      visible: questionnaireJson.navigation,
     };
     this.metadata = this.buildMetadata(questionnaireJson.metadata);
 
@@ -72,7 +79,7 @@ class Questionnaire {
   createContext(questionnaireJson) {
     return {
       routingGotos: [],
-      questionnaireJson
+      questionnaireJson,
     };
   }
 
@@ -94,18 +101,30 @@ class Questionnaire {
           {
             id: `group${introduction.id}`,
             title: "Introduction",
-            blocks: [new Introduction(introduction, ctx)]
-          }
-        ]
+            blocks: [new Introduction(introduction, ctx)],
+          },
+        ],
       },
-      ...this.sections
+      ...this.sections,
     ];
-
     this.sections = newSections;
   }
 
+  buildIntroductionInsideFirstSection(introduction, ctx) {
+    if (!introduction) {
+      return;
+    }
+
+    const introBlock = {
+      id: `group${introduction.id}`,
+      title: "Introduction",
+      blocks: [new Introduction(introduction, ctx)],
+    };
+    this.sections[0].groups.unshift(introBlock);
+  }
+
   buildSections(sections, ctx) {
-    return sections.map(section => new Section(section, ctx));
+    return sections.map((section) => new Section(section, ctx));
   }
 
   buildMetadata(metadata) {
@@ -114,7 +133,7 @@ class Questionnaire {
       .map(({ key, type }) => ({
         name: key,
         type: type === "Date" ? "date" : "string",
-        optional: type === "Text_Optional" || undefined
+        optional: type === "Text_Optional" || undefined,
       }));
 
     return [...DEFAULT_METADATA, ...userMetadata];


### PR DESCRIPTION
https://collaborate2.ons.gov.uk/jira/browse/EAR-1681

### Goal
Allow respondents to be able to view/use the 'Previous' link (which will take a respondent back to the introduction page) on the first question of a questionnaire for linear surveys.

It was found that GCP does not show the 'Previous' link on the first question within a questionnaire.  This link should be there.

**Acceptance criteria**
Runner GCP

GIVEN I am on the first question of a (linear) questionnaire
WHEN I want to navigate back to the introduction page
THEN I can do this (with a 'Previous' link)

**Technical comments:**

Currently the introduction page is put in it's own section for v3. 
For linear surveys only we want to move this introduction page to be the first page in section.

You will need to spin up Publisher-V3 and view a survey tto make sure the "Previous" link is available on the first question
Making sure Hub is set to "False" so it's a linear survey