### PR TITLE
Ear 1714 update route picker

### DIFF
--- a/src/eq_schema/builders/routing2/index.test.js
+++ b/src/eq_schema/builders/routing2/index.test.js
@@ -54,7 +54,7 @@ describe("Routing2", () => {
             ],
           },
           destination: {
-            logical: "EndOfQuestionnaire",
+            logical: "EndOfCurrentSection",
           },
         },
       ],
@@ -70,25 +70,6 @@ describe("Routing2", () => {
       "routing",
       ctx
     );
-    expect(ctx.routingGotos).toMatchObject([
-      {
-        group: "confirmation-group",
-        groupId: "group1",
-        when: {
-          and: [
-            {
-              "any-in": [
-                ["red", "white"],
-                {
-                  identifier: "answer2",
-                  source: "answers",
-                },
-              ],
-            },
-          ],
-        },
-      },
-    ]);
 
     expect(runnerRouting).toMatchObject([
       {
@@ -108,7 +89,7 @@ describe("Routing2", () => {
         },
       },
       {
-        group: "confirmation-group",
+        section: "End",
         when: {
           and: [
             {
@@ -171,7 +152,7 @@ describe("Routing2", () => {
             ],
           },
           destination: {
-            logical: "EndOfQuestionnaire",
+            logical: "EndOfCurrentSection",
           },
         },
       ],
@@ -204,7 +185,7 @@ describe("Routing2", () => {
         },
       },
       {
-        group: "confirmation-group",
+        section: "End",
         when: {
           or: [
             {

--- a/src/eq_schema/builders/routing2/translateRoutingDestination/index.js
+++ b/src/eq_schema/builders/routing2/translateRoutingDestination/index.js
@@ -48,13 +48,7 @@ const getNextPageDestination = (pageId, ctx) => {
 };
 
 const getLogicalDestination = (pageId, { logical }, ctx) => {
-  if (logical === "EndOfQuestionnaire") {
-    return {
-      group: get(ctx.questionnaireJson, "summary")
-        ? "summary-group"
-        : "confirmation-group",
-    };
-  } else if (logical === "EndOfCurrentSection") {
+ if (logical === "EndOfCurrentSection") {
     return {
       section: "End",
     };
@@ -62,9 +56,6 @@ const getLogicalDestination = (pageId, { logical }, ctx) => {
     return getNextPageDestination(pageId, ctx);
   }
 
-  if (logical === "EndOfCurrentSection") {
-    return { section: "End" };
-  }
 
   throw new Error(`${logical} is not a valid destination type`);
 };

--- a/src/eq_schema/builders/routing2/translateRoutingDestination/index.js
+++ b/src/eq_schema/builders/routing2/translateRoutingDestination/index.js
@@ -48,7 +48,7 @@ const getNextPageDestination = (pageId, ctx) => {
 };
 
 const getLogicalDestination = (pageId, { logical }, ctx) => {
- if (logical === "EndOfCurrentSection") {
+  if (logical === "EndOfCurrentSection") {
     return {
       section: "End",
     };

--- a/src/eq_schema/builders/routing2/translateRoutingDestination/index.test.js
+++ b/src/eq_schema/builders/routing2/translateRoutingDestination/index.test.js
@@ -61,26 +61,6 @@ describe("Translation of a routing destination", () => {
     ).toMatchObject({ group: "summary-group" });
   });
 
-  it("should translate a end of questionnaire destination as summary", () => {
-    const authorDestination = {
-      logical: "EndOfQuestionnaire",
-    };
-    expect(
-      translateRoutingDestination(authorDestination, "3", {
-        questionnaireJson: questionnaireJsonWithSummary,
-      })
-    ).toMatchObject({ group: "summary-group" });
-  });
-
-  it("should translate a end of questionnaire destination as confirmation-group", () => {
-    const authorDestination = {
-      logical: "EndOfQuestionnaire",
-    };
-    expect(
-      translateRoutingDestination(authorDestination, "1", { questionnaireJson })
-    ).toMatchObject({ group: "confirmation-group" });
-  });
-
   it("should fail if not provided any destinations", () => {
     const authorDestination = {};
 

--- a/src/eq_schema/schema/Group/index.test.js
+++ b/src/eq_schema/schema/Group/index.test.js
@@ -377,7 +377,7 @@ describe("Group", () => {
         else: {
           section: null,
           page: null,
-          logical: "EndOfQuestionnaire",
+          logical: "EndOfCurrentSection",
         },
       };
 
@@ -419,7 +419,7 @@ describe("Group", () => {
           },
         },
         {
-          group: "confirmation-group",
+          section: "End",
         },
       ];
 


### PR DESCRIPTION
Jira ticket: https://collaborate2.ons.gov.uk/jira/browse/EAR-1714

What is the context of this PR?
At the moment, in v2(AWS) you can route to later sections. In v3(GCP), this will not be required as the Hub Model will be in effect, meaning you don't route to later sections and would route to end of section and back to hub.
This PR just removes tests for end of questionnaire and routing to end of questionnaire 

How to review
Check that everything runs as it should with routing