### PR TITLE
EAR-1739 fix radio and "and" routing errors

### DIFF
--- a/src/eq_schema/builders/routing2/index.js
+++ b/src/eq_schema/builders/routing2/index.js
@@ -22,7 +22,7 @@ const buildRunnerRules = (rules, pageId, ctx, groupId) => {
 
     const { expressions, operator } = rule.expressionGroup;
 
-    if (operator === AND || operator === OR) {
+    if ((operator === AND || operator === OR) && (expressions.length > 1)) {
       const when = expressions.map((expression) =>
         checkValidRoutingType(expression, ctx)
       );

--- a/src/eq_schema/builders/routing2/index.test.js
+++ b/src/eq_schema/builders/routing2/index.test.js
@@ -30,16 +30,6 @@ describe("Routing2", () => {
                   },
                 },
               },
-            ],
-          },
-          destination: {
-            logical: "NextPage",
-          },
-        },
-        {
-          expressionGroup: {
-            operator: AND,
-            expressions: [
               {
                 left: {
                   answerId: "2",
@@ -54,7 +44,7 @@ describe("Routing2", () => {
             ],
           },
           destination: {
-            logical: "EndOfCurrentSection",
+            logical: "NextPage",
           },
         },
       ],
@@ -85,20 +75,13 @@ describe("Routing2", () => {
                 5,
               ],
             },
-          ],
-        },
-      },
-      {
-        section: "End",
-        when: {
-          and: [
             {
-              "any-in": [
-                ["red", "white"],
+              "in": [
                 {
                   identifier: "answer2",
                   source: "answers",
                 },
+                ["red", "white"],
               ],
             },
           ],
@@ -128,16 +111,6 @@ describe("Routing2", () => {
                   optionIds: ["123", "456"],
                 },
               },
-            ],
-          },
-          destination: {
-            logical: "NextPage",
-          },
-        },
-        {
-          expressionGroup: {
-            operator: OR,
-            expressions: [
               {
                 left: {
                   answerId: "2",
@@ -152,7 +125,7 @@ describe("Routing2", () => {
             ],
           },
           destination: {
-            logical: "EndOfCurrentSection",
+            logical: "NextPage",
           },
         },
       ],
@@ -173,28 +146,21 @@ describe("Routing2", () => {
         when: {
           or: [
             {
-              "any-in": [
-                ["red", "white"],
+              "in": [
                 {
                   identifier: "answer1",
                   source: "answers",
                 },
+                ["red", "white"],
               ],
             },
-          ],
-        },
-      },
-      {
-        section: "End",
-        when: {
-          or: [
             {
-              "any-in": [
-                ["red", "white"],
+              "in": [
                 {
                   identifier: "answer2",
                   source: "answers",
                 },
+                ["red", "white"],
               ],
             },
           ],
@@ -694,12 +660,12 @@ describe("Testing Skip Condition Logic", () => {
       when: {
         or: [
           {
-            "any-in": [
-              ["red"],
+            "in": [
               {
                 identifier: "answer27b51b6f-3ada-4b8c-88db-33e21e13172f",
                 source: "answers",
               },
+              ["red"],
             ],
           },
           {

--- a/src/eq_schema/builders/routing2/newRoutingDestination/index.js
+++ b/src/eq_schema/builders/routing2/newRoutingDestination/index.js
@@ -123,6 +123,15 @@ const buildAnswerObject = (
       return SelectedOptions;
     }
 
+    if (condition === "OneOf") {
+      const swapOptionValues = [optionValues[0], optionValues[1]] = [optionValues[1], optionValues[0]];
+      const SelectedOptions = {
+        [routingConditionConversion(condition)]: swapOptionValues,
+      };
+
+      return SelectedOptions;
+    }
+
     const SelectedOptions = {
       [routingConditionConversion(condition)]: optionValues,
     };

--- a/src/eq_schema/builders/routing2/newRoutingDestination/index.test.js
+++ b/src/eq_schema/builders/routing2/newRoutingDestination/index.test.js
@@ -39,12 +39,12 @@ describe("Should build a runner representation of a binary expression", () => {
       });
 
       expect(runnerExpression).toMatchObject({
-        "any-in": [
-          ["red"],
+        "in": [
           {
             identifier: "answer1",
             source: "answers",
           },
+          ["red"],
         ],
       });
     });
@@ -73,12 +73,12 @@ describe("Should build a runner representation of a binary expression", () => {
         questionnaireJson,
       });
       expect(runnerExpression).toMatchObject({
-        "any-in": [
-          ["red", "white"],
+        "in": [
           {
             identifier: "answer1",
             source: "answers",
           },
+          ["red", "white"],
         ],
       });
     });

--- a/src/eq_schema/schema/Group/index.test.js
+++ b/src/eq_schema/schema/Group/index.test.js
@@ -405,19 +405,15 @@ describe("Group", () => {
         {
           group: "groupuu1d-iuhiuwfew-fewfewfewdsf-dsf-4",
           when: {
-            and: [
-              {
-                "==": [
-                  {
-                    identifier: "answer1",
-                    source: "answers",
-                  },
-                  "5",
-                ],
-              },
-            ],
+              "==": [
+                {
+                  identifier: "answer1",
+                  source: "answers",
+                },
+                "5",
+              ],
+            },
           },
-        },
         {
           section: "End",
         },

--- a/src/utils/routingConditionConversion/index.js
+++ b/src/utils/routingConditionConversion/index.js
@@ -9,7 +9,7 @@ const routingConditionConversions = {
   AnyOf: "any-in",
   NotAnyOf: "not",
   Unanswered: "==",
-  OneOf: "any-in",
+  OneOf: "in",
 };
 
 const routingConditionConversion = (conditionString) => {

--- a/src/utils/routingConditionConversion/index.test.js
+++ b/src/utils/routingConditionConversion/index.test.js
@@ -13,7 +13,7 @@ describe("Convert routing conditions", () => {
       AnyOf: "any-in",
       NotAnyOf: "not",
       Unanswered: "==",
-      OneOf: "any-in",
+      OneOf: "in",
     };
     Object.keys(conditionMap).forEach((authorCondition) =>
       expect(routingConditionConversion(authorCondition)).toEqual(


### PR DESCRIPTION

> Check that if single expression is specified in runner then it doesn't wrap the condition in an "and"
> Check it now uses  "in" instead of "any-in"  for radio box selections, and the array order has been swapped 
