### PR TITLE
EAR 1766 fix mutually exclusive

### DIFF
--- a/src/eq_schema/schema/Answer/index.js
+++ b/src/eq_schema/schema/Answer/index.js
@@ -8,10 +8,14 @@ const {
   UNIT,
   DURATION,
   TEXTAREA,
+  CHECKBOX,
+  RADIO,
 } = require("../../../constants/answerTypes");
 const { unitConversion } = require("../../../constants/units");
 
 const { buildContents } = require("../../../utils/builders");
+
+const multipleChoiceAnswers = [CHECKBOX, RADIO];
 
 const getMetadata = (ctx, metadataId) =>
   ctx.questionnaireJson.metadata.find(({ id }) => id === metadataId);
@@ -75,7 +79,10 @@ class Answer {
       }
     }
 
-    if (has(answer, "properties.decimals") && answer.type !== "Checkbox") {
+    if (
+      has(answer, "properties.decimals") &&
+      !multipleChoiceAnswers.includes(answer.type)
+    ) {
       this.decimal_places = answer.properties.decimals;
     }
 
@@ -103,10 +110,7 @@ class Answer {
       }
     }
 
-    if (
-      !isNil(answer.options) &&
-      (answer.type === "Checkbox" || answer.type === "Radio")
-    ) {
+    if (!isNil(answer.options) && multipleChoiceAnswers.includes(answer.type)) {
       this.options = answer.options.map((option) =>
         Answer.buildOption(option, answer, ctx)
       );

--- a/src/eq_schema/schema/Answer/index.js
+++ b/src/eq_schema/schema/Answer/index.js
@@ -75,7 +75,7 @@ class Answer {
       }
     }
 
-    if (has(answer, "properties.decimals")) {
+    if (has(answer, "properties.decimals") && answer.type !== "Checkbox") {
       this.decimal_places = answer.properties.decimals;
     }
 
@@ -103,7 +103,10 @@ class Answer {
       }
     }
 
-    if (!isNil(answer.options)) {
+    if (
+      !isNil(answer.options) &&
+      (answer.type === "Checkbox" || answer.type === "Radio")
+    ) {
       this.options = answer.options.map((option) =>
         Answer.buildOption(option, answer, ctx)
       );

--- a/src/eq_schema/schema/Answer/index.test.js
+++ b/src/eq_schema/schema/Answer/index.test.js
@@ -868,8 +868,15 @@ describe("Answer", () => {
     });
 
     it("should add options even if empty array", () => {
-      const answer = new Answer(createAnswerJSON({ options: [] }));
+      const answer = new Answer(createAnswerJSON({ type: RADIO, options: [] }));
       expect(answer.options).toEqual([]);
+    });
+
+    it("should not add options to non-multiple choice answers", () => {
+      const answer = new Answer(
+        createAnswerJSON({ type: PERCENTAGE, options: [] })
+      );
+      expect(answer.options).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
### PR Context

https://jira.ons.gov.uk/browse/EAR-1766
Fixes an error causing mutually exclusive checkbox answers to include `decimal_places` attribute on numeric answers.
Fixes an issue causing numeric answers to include `options` attribute when the answer includes a mutually exclusive option 

- Create a questionnaire
- Create a numeric answer
- Add a mutually exclusive option (Or option)

**Check:**
- [ ] Mutually exclusive checkbox options do not include a `decimal_places` attribute
- [ ] The numeric answer does not include an `options` attribute
- [ ] Standard radio answers do not cause an error in Runner
- [ ] Standard checkbox answers do not cause an error in Runner