### PR TITLE
EAR 1768 Fix multiple choice value apostrophe bug

### DIFF
--- a/src/eq_schema/schema/Answer/index.js
+++ b/src/eq_schema/schema/Answer/index.js
@@ -207,7 +207,7 @@ class Answer {
   ) {
     const option = {
       label: buildContents(label, ctx),
-      value: buildContents(label, ctx),
+      value: buildContents(label, ctx, true),
     };
 
     if (q_code) {

--- a/src/utils/HTMLUtils/index.js
+++ b/src/utils/HTMLUtils/index.js
@@ -5,14 +5,23 @@ const { replace } = require("lodash/fp");
 const isPlainText = (elem) => typeof elem === "string" && !elem.startsWith("<");
 
 const startsWithLink = (elem) =>
-  typeof elem === "string" && (elem.startsWith("<a") || elem.startsWith("<strong>")) ;
+  typeof elem === "string" &&
+  (elem.startsWith("<a") || elem.startsWith("<strong>"));
 
 const getInnerHTML = (elem) =>
   isPlainText(elem) || startsWithLink(elem) ? elem : cheerio(elem).html();
 
 const removeDash = (elem) => replace(/-/g, "_", elem);
 
-const unescapePiping = (value) => replace(/&apos;/g, `&#39;`, value);
+const unescapePiping = (value, isMultipleChoiceValue) => {
+  let updatedValue;
+  if (!isMultipleChoiceValue) {
+    updatedValue = replace(/&apos;/g, `&#39;`, value);
+  } else {
+    updatedValue = replace(/&apos;/g, `'`, value);
+  }
+  return updatedValue;
+};
 
 const getInnerHTMLWithPiping = (elem) => {
   if (!elem) {

--- a/src/utils/builders/index.js
+++ b/src/utils/builders/index.js
@@ -3,10 +3,11 @@ const convertPipes = require("../convertPipes");
 
 const { getInnerHTMLWithPiping } = require("../HTMLUtils");
 
-const processPipe = (ctx) => flow(convertPipes(ctx), getInnerHTMLWithPiping);
+const processPipe = (ctx, isMultipleChoiceValue) =>
+  flow(convertPipes(ctx, isMultipleChoiceValue), getInnerHTMLWithPiping);
 
-const buildContents = (title, ctx) => {
-  return processPipe(ctx)(title);
+const buildContents = (title, ctx, isMultipleChoiceValue) => {
+  return processPipe(ctx, isMultipleChoiceValue)(title);
 };
 
 const buildIntroductionTitle = () => {

--- a/src/utils/convertPipes/index.js
+++ b/src/utils/convertPipes/index.js
@@ -115,7 +115,7 @@ const getPipedData = (store) => (element, ctx) => {
   return `{${removeDash(output)}}`;
 };
 
-const convertPipes = (ctx) => (html) => {
+const convertPipes = (ctx, isMultipleChoiceValue) => (html) => {
   if (!html) {
     return html;
   }
@@ -132,7 +132,7 @@ const convertPipes = (ctx) => (html) => {
     $elem.replaceWith(getPipedData(store)($elem, ctx));
   });
 
-  store.text = unescapePiping($.html());
+  store.text = unescapePiping($.html(), isMultipleChoiceValue);
 
   if (!store.placeholders.length) {
     return store.text;


### PR DESCRIPTION
### What is the context of this PR?

https://jira.ons.gov.uk/browse/EAR-1768

Fixes a bug preventing questions from progressing in Runner when multiple choice answers (radio, checkbox, or mutually exclusive) include an apostrophe in the label.

### How to review

- Create a questionnaire
- Add checkbox answers, radio answers, and mutually exclusive answers ("Or" options) - include an apostrophe in each label
- Add other answer types such as numeric answers, date answers, or text answers - include an apostrophe in each label
- Extract the questionnaire's Runner JSON data and view the survey in Questionnaire Runner

**Check:**
- [ ] Multiple choice answer option `value` attributes include the character `'` to represent an apostrophe, and do not include `&#39;`
- [ ] All other apostrophes in the questionnaire are represented using `&#39;`, and do not include the character `'`
- [ ] When viewing the survey, non-multiple choice answers that include an apostrophe progress correctly through the questionnaire
- [ ] When viewing the survey, multiple choice answers that include an apostrophe progress correctly through the questionnaire