### PR TITLE
Ear 1654 more than one mutually exclusive and EAR 1667 add mutually exclusive to multiple answer types

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "node ./src/server.js",
     "develop": "nodemon yarn start",
     "lint": "eslint .",
-    "test": "jest --watch",
+    "test": "jest --watchAll",
     "test-ci": "jest"
   },
   "dependencies": {

--- a/src/constants/answerTypes.js
+++ b/src/constants/answerTypes.js
@@ -9,6 +9,7 @@ const DATE_RANGE = "DateRange";
 const PERCENTAGE = "Percentage";
 const UNIT = "Unit";
 const DURATION = "Duration";
+const MUTUALLY_EXCLUSIVE = "MutuallyExclusive";
 
 module.exports = {
   CHECKBOX,
@@ -21,5 +22,6 @@ module.exports = {
   DATE_RANGE,
   PERCENTAGE,
   UNIT,
-  DURATION
+  DURATION,
+  MUTUALLY_EXCLUSIVE,
 };

--- a/src/eq_schema/builders/routing2/newRoutingDestination/index.js
+++ b/src/eq_schema/builders/routing2/newRoutingDestination/index.js
@@ -1,5 +1,6 @@
 const routingConditionConversion = require("../../../../utils/routingConditionConversion");
 const { flatMap, filter } = require("lodash");
+const { MUTUALLY_EXCLUSIVE } = require("../../../../constants/answerTypes");
 
 const authorConditions = {
   UNANSWERED: "Unanswered",
@@ -43,19 +44,8 @@ const mutuallyExclusiveId = (left, right, ctx) => {
     flatMap(section.folders, (folder) =>
       flatMap(folder.pages, (page) =>
         flatMap(page.answers, (answer) => {
-          const options = answer.options ? answer.options : [];
-
-          if (options.length !== 0) {
-            options.map((option) => {
-              if (
-                option.id === right.optionIds[0] &&
-                option.mutuallyExclusive
-              ) {
-                option.id = `${option.id}-exclusive`;
-                left.answerId = `${left.answerId}-exclusive`;
-                right.optionIds[0] = `${right.optionIds[0]}-exclusive`;
-              }
-            });
+          if (answer.type === MUTUALLY_EXCLUSIVE) {
+            answer.id = `${answer.id}-exclusive`;
           }
         })
       )
@@ -124,7 +114,10 @@ const buildAnswerObject = (
     }
 
     if (condition === "OneOf") {
-      const swapOptionValues = [optionValues[0], optionValues[1]] = [optionValues[1], optionValues[0]];
+      const swapOptionValues = ([optionValues[0], optionValues[1]] = [
+        optionValues[1],
+        optionValues[0],
+      ]);
       const SelectedOptions = {
         [routingConditionConversion(condition)]: swapOptionValues,
       };

--- a/src/eq_schema/schema/Answer/index.js
+++ b/src/eq_schema/schema/Answer/index.js
@@ -10,12 +10,13 @@ const {
   TEXTAREA,
   CHECKBOX,
   RADIO,
+  MUTUALLY_EXCLUSIVE,
 } = require("../../../constants/answerTypes");
 const { unitConversion } = require("../../../constants/units");
 
 const { buildContents } = require("../../../utils/builders");
 
-const multipleChoiceAnswers = [CHECKBOX, RADIO];
+const multipleChoiceAnswers = [CHECKBOX, RADIO, MUTUALLY_EXCLUSIVE];
 
 const getMetadata = (ctx, metadataId) =>
   ctx.questionnaireJson.metadata.find(({ id }) => id === metadataId);

--- a/src/eq_schema/schema/Question/index.js
+++ b/src/eq_schema/schema/Question/index.js
@@ -1,5 +1,5 @@
-const { find, get, flow, concat, last, filter } = require("lodash/fp");
-const { set, remove, cloneDeep, isArguments } = require("lodash");
+const { find, get, flow, concat, last } = require("lodash/fp");
+const { set, remove, cloneDeep } = require("lodash");
 
 const { getInnerHTMLWithPiping } = require("../../../utils/HTMLUtils");
 const convertPipes = require("../../../utils/convertPipes");
@@ -15,7 +15,6 @@ const {
   DATE_RANGE,
   MUTUALLY_EXCLUSIVE,
 } = require("../../../constants/answerTypes");
-const e = require("express");
 
 const findDateRange = flow(get("answers"), find({ type: DATE_RANGE }));
 

--- a/src/eq_schema/schema/Question/index.js
+++ b/src/eq_schema/schema/Question/index.js
@@ -1,5 +1,5 @@
 const { find, get, flow, concat, last, filter } = require("lodash/fp");
-const { set, remove, cloneDeep } = require("lodash");
+const { set, remove, cloneDeep, isArguments } = require("lodash");
 
 const { getInnerHTMLWithPiping } = require("../../../utils/HTMLUtils");
 const convertPipes = require("../../../utils/convertPipes");
@@ -10,7 +10,12 @@ const {
 
 const Answer = require("../Answer");
 
-const { DATE, DATE_RANGE } = require("../../../constants/answerTypes");
+const {
+  DATE,
+  DATE_RANGE,
+  MUTUALLY_EXCLUSIVE,
+} = require("../../../constants/answerTypes");
+const e = require("express");
 
 const findDateRange = flow(get("answers"), find({ type: DATE_RANGE }));
 
@@ -93,6 +98,16 @@ class Question {
         ctx
       );
       delete this.answers[1].label;
+    } else if (
+      question.answers.some((answer) => answer.type === MUTUALLY_EXCLUSIVE)
+    ) {
+      this.type = "MutuallyExclusive";
+      this.mandatory = false;
+      this.answers = this.buildMutuallyExclusiveAnswers(
+        mutuallyExclusive,
+        question.answers,
+        ctx
+      );
     } else if (question.totalValidation && question.totalValidation.enabled) {
       this.type = "Calculated";
       this.answers = this.buildAnswers(question.answers, ctx);
@@ -161,13 +176,34 @@ class Question {
   }
 
   buildMutuallyExclusiveAnswers(mutuallyExclusive, answers, ctx) {
-    Object.assign(mutuallyExclusive.properties, { required: false });
-    const mutuallyExclusiveAnswer = new Answer({
-      ...mutuallyExclusive,
-      id: `${mutuallyExclusive.id}-exclusive`,
-      type: "Checkbox",
-      options: filter({ mutuallyExclusive: true }, mutuallyExclusive.options),
+    let mutuallyExclusiveAnswer;
+    answers.forEach((answer) => {
+      if (answer.type === MUTUALLY_EXCLUSIVE && answer.options.length === 1) {
+        answers = answers.filter(
+          (answer) => answer.type !== MUTUALLY_EXCLUSIVE
+        );
+        mutuallyExclusiveAnswer = new Answer({
+          ...answer,
+          id: `${answer.id}-exclusive`,
+          type: "Checkbox",
+        });
+      } else if (
+        answer.type === MUTUALLY_EXCLUSIVE &&
+        answer.options.length > 1
+      ) {
+        answers = answers.filter(
+          (answer) => answer.type !== MUTUALLY_EXCLUSIVE
+        );
+        mutuallyExclusiveAnswer = new Answer({
+          ...answer,
+          id: `${answer.id}-exclusive`,
+          type: "Radio",
+        });
+      } else {
+        return;
+      }
     });
+
     return concat(this.buildAnswers(answers, ctx), mutuallyExclusiveAnswer);
   }
 

--- a/src/eq_schema/schema/Question/index.js
+++ b/src/eq_schema/schema/Question/index.js
@@ -88,15 +88,6 @@ class Question {
           );
         }
       }
-    } else if (mutuallyExclusive) {
-      this.type = "MutuallyExclusive";
-      this.mandatory = get("properties.required", mutuallyExclusive);
-      this.answers = this.buildMutuallyExclusiveAnswers(
-        mutuallyExclusive,
-        question.answers,
-        ctx
-      );
-      delete this.answers[1].label;
     } else if (
       question.answers.some((answer) => answer.type === MUTUALLY_EXCLUSIVE)
     ) {

--- a/src/eq_schema/schema/Question/index.test.js
+++ b/src/eq_schema/schema/Question/index.test.js
@@ -736,7 +736,7 @@ describe("Question", () => {
     });
 
     // TODO: This test can be edited after confirmation on mandatory and mutually exclusive requirements
-    it("should set mandatory on exclusive child answers to false", () => {
+    // it("should set mandatory on exclusive child answers to false", () => {
     //   const question = new Question(createQuestionJSON({ answers }));
     //   expect(question).toMatchObject({
     //     mandatory: true,
@@ -783,7 +783,7 @@ describe("Question", () => {
       ]);
     });
 
-    it("should have multiple options in the mutually exclusive answer", () => {
+    it("should have a multiple options in the mutually exclusive answer", () => {
       const question = new Question(createQuestionJSON({ answers }));
       expect(last(question.answers).options).toEqual([
         {

--- a/src/eq_schema/schema/Question/index.test.js
+++ b/src/eq_schema/schema/Question/index.test.js
@@ -736,7 +736,7 @@ describe("Question", () => {
     });
 
     // TODO: This test can be edited after confirmation on mandatory and mutually exclusive requirements
-    // it("should set mandatory on exclusive child answers to false", () => {
+    it("should set mandatory on exclusive child answers to false", () => {
     //   const question = new Question(createQuestionJSON({ answers }));
     //   expect(question).toMatchObject({
     //     mandatory: true,
@@ -783,7 +783,7 @@ describe("Question", () => {
       ]);
     });
 
-    it("should have a multiple options in the mutually exclusive answer", () => {
+    it("should have multiple options in the mutually exclusive answer", () => {
       const question = new Question(createQuestionJSON({ answers }));
       expect(last(question.answers).options).toEqual([
         {


### PR DESCRIPTION
# Do not merge this PR - currently Runner does not support pages with multiple answers and a mutually exclusive option, therefore these changes will not be available in Runner - the required Runner changes cannot be made by our team. Currently the code and schema structure can be reviewed, however not all of this functionality can be tested until the Runner changes are made - a re-review will be required once these changes have been made. Functionality that cannot be tested is labelled in the review instructions

### What is the context of this PR?

- Adds support for mutually exclusive options on pages with multiple answer types - previously mutually exclusive options could only be included if the page had only one answer
- Adds support for multiple mutually exclusive options on a page

**Tickets**
https://jira.ons.gov.uk/browse/EAR-1654
https://jira.ons.gov.uk/browse/EAR-1667

**Author PR**
https://github.com/ONSdigital/eq-author-app/pull/2699

## How to review

Checks ending with "**requires Runner changes**" will not work until the required Runner changes have been made

**Check:**
- [ ] If the question page includes multiple mutually exclusive options, all options are displayed at the end of the page with the word "Or" before them
- [ ] Selecting a mutually exclusive option deletes the input of any other answer **(can be tested for one answer, testing for multiple answers requires Runner changes)**
- [ ] If the question page includes one mutually exclusive option, the option is displayed as a checkbox
- [ ] If the question page includes multiple mutually exclusive options, the options are displayed as radios, and only one option can be selected
- [ ] If the question page includes multiple answers and a mutually exclusive option, all answers are displayed with the mutually exclusive option **(requires Runner changes)**

_Runner schema_
- [ ] The Runner schema output is accurate when a mutually exclusive answer is included
- [ ] When a mutually exclusive answer is included, the question's type is "MutuallyExclusive"
- [ ] When a mutually exclusive answer is included, the mutually exclusive answer has either type "Checkbox" or "Radio" ("Checkbox" if the answer has one option, "Radio" if the answer has multiple options)
- [ ] The mutually exclusive answer's ID has "-exclusive" included at the end