### PR TITLE
EAR 1699 Fix list collector routing to repeating question

### DIFF
--- a/src/eq_schema/builders/routing2/translateRoutingDestination/index.js
+++ b/src/eq_schema/builders/routing2/translateRoutingDestination/index.js
@@ -1,8 +1,13 @@
 const { flatMap, get, findIndex, isNil } = require("lodash");
+const { getPageById } = require("../../../../utils/functions/pageGetters");
 
 const getAbsoluteDestination = (destination, ctx) => {
-  if (destination.pageId) {
+  const page = getPageById(ctx, destination.pageId);
+  if (destination.pageId && page.pageType !== "ListCollectorPage") {
     return { block: `block${destination.pageId}` };
+  }
+  if (destination.pageId && page.pageType === "ListCollectorPage") {
+    return { block: `block-driving${destination.pageId}` };
   }
 
   // Get first folder in the section when routing to sections
@@ -55,7 +60,6 @@ const getLogicalDestination = (pageId, { logical }, ctx) => {
   } else if (logical === "NextPage") {
     return getNextPageDestination(pageId, ctx);
   }
-
 
   throw new Error(`${logical} is not a valid destination type`);
 };

--- a/src/utils/functions/pageGetters.js
+++ b/src/utils/functions/pageGetters.js
@@ -1,0 +1,16 @@
+const getPageById = (ctx, pageId) => {
+  let result;
+  ctx.questionnaireJson.sections.forEach((section) => {
+    section.folders.forEach((folder) => {
+      folder.pages.forEach((page) => {
+        if (page.id === pageId) {
+          result = page;
+        }
+      });
+    });
+  });
+
+  return result;
+};
+
+module.exports = { getPageById };


### PR DESCRIPTION
**Context**
Fixes a bug causing routing to a list collector question to route to the repeating question instead of the driving question

**How to review**
Check:
- [ ] Routing to list collector question routes to the driving question
- [ ] Skip logic is applied to skip to a list driving question
- [ ] Routing logic is applied correctly to non-list page destinations