### PR TITLE
Bug fix

### DIFF
--- a/src/eq_schema/builders/confirmationPage/ConfirmationPage.js
+++ b/src/eq_schema/builders/confirmationPage/ConfirmationPage.js
@@ -48,10 +48,10 @@ const buildAuthorConfirmationQuestion = (page, groupId, routing, ctx) => {
   };
 
   const checkBoxTransform = [{
-    text: "{checkboxAnswers}",
+    text: "{checkbox_answers}",
     placeholders: [
       {
-        placeholder: "checkboxAnswers",
+        placeholder: "checkbox_answers",
         transforms: [
           {
             transform: "format_list",

--- a/src/eq_schema/schema/Group/index.test.js
+++ b/src/eq_schema/schema/Group/index.test.js
@@ -448,9 +448,9 @@ describe("Group", () => {
       const resultantJson = new Group(folder, ctx);
       expect(resultantJson.blocks[1].question.description).toEqual([
         {
-          text: "{checkboxAnswers}",
+          text: "{checkbox_answers}",
           placeholders: [{
-            placeholder: "checkboxAnswers",
+            placeholder: "checkbox_answers",
             transforms: [{
               arguments: {
                 list_to_format: {


### PR DESCRIPTION
Change in checkBoxTransform to ensure when used 'text' and 'placeholder' generate in a format that passes validation in eq_questionnaire_schemas.

Basically the validation does not allow for uppercase characters, so changing the format from camelCase