### PR TITLE
Add meaningful placeholders for piped answers

### DIFF
--- a/src/eq_schema/schema/Block/index.test.js
+++ b/src/eq_schema/schema/Block/index.test.js
@@ -124,7 +124,7 @@ describe("Block", () => {
           folders: [
             {
               id: "folder-1",
-              pages: [{ answers: [{ id: `1`, type: "Text" }] }]
+              pages: [{ answers: [{ id: `1`, label: "Answer 1", type: "Text" }] }]
             }
           ],
         }]
@@ -139,7 +139,7 @@ describe("Block", () => {
         createContext()
       );
       expect(introBlock.content.title).toEqual(
-        createPipedFormat("untitled_answer", "answer1", "answers")
+        createPipedFormat("Answer_1", "answer1", "answers")
       );
     });
 
@@ -152,7 +152,7 @@ describe("Block", () => {
       );
 
       expect(introBlock.content.title).toEqual(
-        createPipedFormat("untitled_answer", "answer1", "answers")
+        createPipedFormat("Answer_1", "answer1", "answers")
       );
     });
 
@@ -164,7 +164,7 @@ describe("Block", () => {
         createContext()
       );
       expect(introBlock.content.contents[0].list).toEqual([
-        createPipedFormat("untitled_answer", "answer1", "answers"),
+        createPipedFormat("Answer_1", "answer1", "answers"),
         "Some Value"
       ]);
     });

--- a/src/eq_schema/schema/Block/index.test.js
+++ b/src/eq_schema/schema/Block/index.test.js
@@ -139,7 +139,7 @@ describe("Block", () => {
         createContext()
       );
       expect(introBlock.content.title).toEqual(
-        createPipedFormat("1", "answer1", "answers")
+        createPipedFormat("untitled_answer", "answer1", "answers")
       );
     });
 
@@ -152,7 +152,7 @@ describe("Block", () => {
       );
 
       expect(introBlock.content.title).toEqual(
-        createPipedFormat("1", "answer1", "answers")
+        createPipedFormat("untitled_answer", "answer1", "answers")
       );
     });
 
@@ -164,7 +164,7 @@ describe("Block", () => {
         createContext()
       );
       expect(introBlock.content.contents[0].list).toEqual([
-        createPipedFormat("1", "answer1", "answers"),
+        createPipedFormat("untitled_answer", "answer1", "answers"),
         "Some Value"
       ]);
     });

--- a/src/eq_schema/schema/Question/index.test.js
+++ b/src/eq_schema/schema/Question/index.test.js
@@ -16,6 +16,7 @@ describe("Question", () => {
         answers: [
           {
             id: "1",
+            label: "A1",
             properties: {
               required: true,
             },
@@ -605,7 +606,7 @@ describe("Question", () => {
         }),
         createContext()
       );
-      expect(question.title).toEqual(createPipedFormat("1", "answer1", "answers"));
+      expect(question.title).toEqual(createPipedFormat("untitled_answer", "answer1", "answers"));
     });
 
     it("should handle piped values in guidance", () => {
@@ -645,7 +646,7 @@ describe("Question", () => {
         createContext()
       );
       expect(question.description).toEqual([
-        createPipedFormat("1", "answer1", "answers"),
+        createPipedFormat("untitled_answer", "answer1", "answers"),
       ]);
     });
   });

--- a/src/eq_schema/schema/Question/index.test.js
+++ b/src/eq_schema/schema/Question/index.test.js
@@ -16,7 +16,6 @@ describe("Question", () => {
         answers: [
           {
             id: "1",
-            label: "A1",
             properties: {
               required: true,
             },
@@ -591,7 +590,7 @@ describe("Question", () => {
             folders: [
               {
                 id: "folder-1",
-                pages: [{ answers: [{ id: `1`, label: "A1", type: "Text" }] }],
+                pages: [{ answers: [{ id: `1`, label: "A label?", type: "Text" }] }],
               },
             ],
           },
@@ -606,7 +605,7 @@ describe("Question", () => {
         }),
         createContext()
       );
-      expect(question.title).toEqual(createPipedFormat("A1", "answer1", "answers"));
+      expect(question.title).toEqual(createPipedFormat("A_label", "answer1", "answers"));
     });
 
     it("should handle piped values in guidance", () => {
@@ -646,7 +645,7 @@ describe("Question", () => {
         createContext()
       );
       expect(question.description).toEqual([
-        createPipedFormat("A1", "answer1", "answers"),
+        createPipedFormat("A_label", "answer1", "answers"),
       ]);
     });
   });

--- a/src/eq_schema/schema/Question/index.test.js
+++ b/src/eq_schema/schema/Question/index.test.js
@@ -591,7 +591,7 @@ describe("Question", () => {
             folders: [
               {
                 id: "folder-1",
-                pages: [{ answers: [{ id: `1`, type: "Text" }] }],
+                pages: [{ answers: [{ id: `1`, label: "A1", type: "Text" }] }],
               },
             ],
           },
@@ -606,7 +606,7 @@ describe("Question", () => {
         }),
         createContext()
       );
-      expect(question.title).toEqual(createPipedFormat("untitled_answer", "answer1", "answers"));
+      expect(question.title).toEqual(createPipedFormat("A1", "answer1", "answers"));
     });
 
     it("should handle piped values in guidance", () => {
@@ -646,7 +646,7 @@ describe("Question", () => {
         createContext()
       );
       expect(question.description).toEqual([
-        createPipedFormat("untitled_answer", "answer1", "answers"),
+        createPipedFormat("A1", "answer1", "answers"),
       ]);
     });
   });

--- a/src/utils/convertPipes/index.js
+++ b/src/utils/convertPipes/index.js
@@ -51,7 +51,17 @@ const PIPE_TYPES = {
       return getAnswer(ctx, tempId);
     },
     render: ({ id }) => id,
-    placeholder: ({ id }) => id,
+    placeholder: ({ label }) => {
+      if (label) {
+        var formattedLabel = label;
+        formattedLabel = formattedLabel.replace(/[^a-zA-Z0-9 ]/g, "");
+        formattedLabel = formattedLabel.replace(/ /g, "_");
+        return formattedLabel
+      }
+      else {
+        return 'untitled_answer';
+      }
+    },
     getType: ({ type }) => type,
     getFallback: ({ properties, id, type, advancedProperties }) => {
       if (!(type === "DateRange") || !advancedProperties) {

--- a/src/utils/convertPipes/index.test.js
+++ b/src/utils/convertPipes/index.test.js
@@ -59,18 +59,20 @@ const createContext = (metadata = []) => ({
             pages: [
               {
                 answers: [
-                  { id: `1`, type: "Text" },
-                  { id: `2`, type: "Currency" },
-                  { id: `3`, type: "DateRange" },
+                  { id: `1`, label: "Question One", type: "Text" },
+                  { id: `2`, label: "", type: "Currency" },
+                  { id: `3`, label: "!It's Q3?", type: "DateRange" },
                   {
                     id: `4`,
+                    label: "#Q4Don'tDoIt", 
                     type: "Date",
                     properties: { format: "dd/mm/yyyy" },
                   },
-                  { id: `5`, type: "Number" },
-                  { id: `6`, type: "Unit", properties: { unit: "Kilometres" } },
+                  { id: `5`, label: "label of excellence", type: "Number" },
+                  { id: `6`, label: "BACWards 6q", type: "Unit", properties: { unit: "Kilometres" } },
                   {
                     id: `7`,
+                    label: "Q7 Checkbox Options?",
                     type: "Checkbox",
                     options: [
                       {
@@ -141,9 +143,9 @@ describe("convertPipes", () => {
       const html = createPipe();
       expect(convertPipes(createContext())(html)).toEqual(
         createWrapper(
-          "{1}",
+          "{Question_One}",
           createPlaceholders({
-            placeholder: "1",
+            placeholder: "Question_One",
             identifier: "answer1",
             source: "answers",
           })
@@ -158,14 +160,14 @@ describe("convertPipes", () => {
 
       expect(convertPipes(createContext())(html)).toEqual(
         createWrapper(
-          "{1}{2}",
+          "{Question_One}{untitled_answer}",
           createPlaceholders({
-            placeholder: "1",
+            placeholder: "Question_One",
             identifier: "answer1",
             source: "answers",
           }),
           createTransformation({
-            placeholder: "2",
+            placeholder: "untitled_answer",
             identifier:  "answer2",
             source: "answers",
             argument: "number",
@@ -182,14 +184,14 @@ describe("convertPipes", () => {
 
       expect(convertPipes(createContext())(html)).toEqual(
         createWrapper(
-          "hello {1}{2} world",
+          "hello {Question_One}{untitled_answer} world",
           createPlaceholders({
-            placeholder: "1",
+            placeholder: "Question_One",
             identifier: "answer1",
             source: "answers",
           }),
           createTransformation({
-            placeholder: "2",
+            placeholder: "untitled_answer",
             identifier: "answer2",
             source: "answers",
             argument: "number",
@@ -204,10 +206,10 @@ describe("convertPipes", () => {
         const html = createPipe({ id: "3" });
         expect(convertPipes(createContext())(html)).toEqual(
           createWrapper(
-            "{3}",
+            "{Its_Q3}",
             createTransformation(
               {
-                placeholder: "3",
+                placeholder: "Its_Q3",
                 identifier: "answer3",
                 source: "answers",
                 argument: "date_to_format",
@@ -223,10 +225,10 @@ describe("convertPipes", () => {
         const html = createPipe({ id: "4" });
         expect(convertPipes(createContext())(html)).toEqual(
           createWrapper(
-            "{4}",
+            "{Q4DontDoIt}",
             createTransformation(
               {
-                placeholder: "4",
+                placeholder: "Q4DontDoIt",
                 identifier: "answer4",
                 source: "answers",
                 argument: "date_to_format",
@@ -242,9 +244,9 @@ describe("convertPipes", () => {
         const html = createPipe({ id: "2" });
         expect(convertPipes(createContext())(html)).toEqual(
           createWrapper(
-            "{2}",
+            "{untitled_answer}",
             createTransformation({
-              placeholder: "2",
+              placeholder: "untitled_answer",
               identifier: "answer2",
               source: "answers",
               argument: "number",
@@ -258,9 +260,9 @@ describe("convertPipes", () => {
         const html = createPipe({ id: "5" });
         expect(convertPipes(createContext())(html)).toEqual(
           createWrapper(
-            "{5}",
+            "{label_of_excellence}",
             createTransformation({
-              placeholder: "5",
+              placeholder: "label_of_excellence",
               identifier: "answer5",
               source: "answers",
               argument: "number",
@@ -274,10 +276,10 @@ describe("convertPipes", () => {
         const html = createPipe({ id: "7" });
         expect(convertPipes(createContext())(html)).toEqual(
           createWrapper(
-            "{7}",
+            "{Q7_Checkbox_Options}",
             createCheckboxTransformation(
               {
-                placeholder: "7",
+                placeholder: "Q7_Checkbox_Options",
                 transform: "concatenate_list",
               },
               {


### PR DESCRIPTION
Updates placeholder values for piped answers to use the label value rather than the id.
Label value is formatted to remove all non-alphanumeric characters, and replace spaces with underscores

Updates can be verified using the export/convert urls on a questionnaire with piped answers, ensuring that piped answers with valid labels are converted and used as appropriate placeholders. If a label is optional and not completed, it should return a placeholder value of 'untitled_answer'.