### PR TITLE
Ear 1893 piping date range answers

### DIFF
--- a/src/utils/convertPipes/index.js
+++ b/src/utils/convertPipes/index.js
@@ -52,6 +52,7 @@ const PIPE_TYPES = {
     },
     render: ({ id }) => id,
     placeholder: ({ label, secondaryLabel, type, id }) => {
+      // Define a new function to format labels
       const formatter = (l) => {
         if (l) {
           var formattedLabel = l;
@@ -145,6 +146,7 @@ const getPipedData = (store) => (element, ctx) => {
 
   const { label } = entity;
   const { secondaryLabel } = entity;
+  // Create a new element consisting of both 'label' and 'secondaryLabel' along with 'elementData' for 'DateRange' answer types
   const dateRangeElement = { ...elementData, label, secondaryLabel };
 
   const placeholderName =

--- a/src/utils/convertPipes/index.js
+++ b/src/utils/convertPipes/index.js
@@ -144,8 +144,7 @@ const getPipedData = (store) => (element, ctx) => {
     return "";
   }
 
-  const { label } = entity;
-  const { secondaryLabel } = entity;
+  const { label, secondaryLabel } = entity;
   // Create a new element consisting of both 'label' and 'secondaryLabel' along with 'elementData' for 'DateRange' answer types
   const dateRangeElement = { ...elementData, label, secondaryLabel };
 

--- a/src/utils/convertPipes/index.js
+++ b/src/utils/convertPipes/index.js
@@ -63,7 +63,7 @@ const PIPE_TYPES = {
           return "untitled_answer";
         }
       };
-
+      // The placeholders will now be 'label' and 'secondaryLabel' values, hence different for the piped date range values.
       if (type === "DateRange") {
         return id.endsWith("from")
           ? formatter(label)

--- a/src/utils/convertPipes/index.js
+++ b/src/utils/convertPipes/index.js
@@ -51,15 +51,24 @@ const PIPE_TYPES = {
       return getAnswer(ctx, tempId);
     },
     render: ({ id }) => id,
-    placeholder: ({ label }) => {
-      if (label) {
-        var formattedLabel = label;
-        formattedLabel = formattedLabel.replace(/[^a-zA-Z0-9 ]/g, "");
-        formattedLabel = formattedLabel.replace(/ /g, "_");
-        return formattedLabel
-      }
-      else {
-        return 'untitled_answer';
+    placeholder: ({ label, secondaryLabel, type, id }) => {
+      const formatter = (l) => {
+        if (l) {
+          var formattedLabel = l;
+          formattedLabel = formattedLabel.replace(/[^a-zA-Z0-9 ]/g, "");
+          formattedLabel = formattedLabel.replace(/ /g, "_");
+          return formattedLabel;
+        } else {
+          return "untitled_answer";
+        }
+      };
+
+      if (type === "DateRange") {
+        return id.endsWith("from")
+          ? formatter(label)
+          : formatter(secondaryLabel);
+      } else {
+        return formatter(label);
       }
     },
     getType: ({ type }) => type,
@@ -134,9 +143,13 @@ const getPipedData = (store) => (element, ctx) => {
     return "";
   }
 
+  const { label } = entity;
+  const { secondaryLabel } = entity;
+  const dateRangeElement = { ...elementData, label, secondaryLabel };
+
   const placeholderName =
     elementData.type === "DateRange"
-      ? pipeConfig.placeholder(elementData)
+      ? pipeConfig.placeholder(dateRangeElement)
       : pipeConfig.placeholder(entity);
 
   const identifier =

--- a/src/utils/convertPipes/index.js
+++ b/src/utils/convertPipes/index.js
@@ -144,6 +144,7 @@ const getPipedData = (store) => (element, ctx) => {
     return "";
   }
 
+  // Extract 'label' and 'secondaryLabel' values from 'entity'
   const { label, secondaryLabel } = entity;
   // Create a new element consisting of both 'label' and 'secondaryLabel' along with 'elementData' for 'DateRange' answer types
   const dateRangeElement = { ...elementData, label, secondaryLabel };


### PR DESCRIPTION
Steps to replicate the bug in Master branch -

- Create a question with date range answer, enter both start and end date labels
- Create another question, and pipe both the date range 'from' and 'to' values into the question title
- View the questionnaire in Runner - enter start and end dates in the date range question
- View the question from Step 2 in Runner
- The question title in Step 2 will have the start date piped in twice

How to review -

- Checkout this branch and restart 'eq-publisher-v3' application from terminal in local
- Create a question with date range answer, enter both start and end date labels
- Create another question, and pipe both the date range 'from' and 'to' values into the question title
- View the questionnaire in Runner - enter start and end dates in the date range question
- View the question from Step 2 in Runner
- The question title in Step 2 must have both the start and end dates piped in at the proper places