### PR TITLE
Bug fix

### DIFF
--- a/src/eq_schema/schema/Question/index.js
+++ b/src/eq_schema/schema/Question/index.js
@@ -171,14 +171,19 @@ class Question {
     answers.forEach((answer) => {
       answer.properties.required = false;
       if (answer.type === MUTUALLY_EXCLUSIVE && answer.options.length === 1) {
+
         answers = answers.filter(
           (answer) => answer.type !== MUTUALLY_EXCLUSIVE
         );
-        mutuallyExclusiveAnswer = new Answer({
+        const tempAnswer = {
           ...answer,
           id: `${answer.id}-exclusive`,
           type: "Checkbox",
-        });
+        }
+        tempAnswer.options[0].qCode = answer.qCode
+        delete tempAnswer.qCode
+        mutuallyExclusiveAnswer = new Answer(tempAnswer);
+
       } else if (
         answer.type === MUTUALLY_EXCLUSIVE &&
         answer.options.length > 1


### PR DESCRIPTION
Bug fix for single option mutually exclusive answers, where the QCode was being written into the answer instead of the option.

### To Test

1. Create an answer with only one mutually exclusive option
2. Open the QCodes page, and enter a QCode for "Mutually exclusive"
3. View Runner schema (/convert/<questionnaire_id>)

- Confirm that the UI entered q_code appears in the single option, and not at the answer level.
- Confirm that the change does not effect ME answers with more than one ME option.
- Confirm that the change does not effect Checkbox answers on non-ME answers.

### Links
https://jira.ons.gov.uk/browse/EAR-1895