### PR TITLE
EAR-1898 mutually exclusive ID bug

### DIFF
--- a/src/eq_schema/builders/routing2/newRoutingDestination/index.js
+++ b/src/eq_schema/builders/routing2/newRoutingDestination/index.js
@@ -1,6 +1,5 @@
 const routingConditionConversion = require("../../../../utils/routingConditionConversion");
 const { flatMap, filter } = require("lodash");
-const { MUTUALLY_EXCLUSIVE } = require("../../../../constants/answerTypes");
 
 const authorConditions = {
   UNANSWERED: "Unanswered",
@@ -37,20 +36,6 @@ const checkType = (type) => {
   }
 
   return null;
-};
-
-const mutuallyExclusiveId = (left, right, ctx) => {
-  flatMap(ctx.questionnaireJson.sections, (section) =>
-    flatMap(section.folders, (folder) =>
-      flatMap(folder.pages, (page) =>
-        flatMap(page.answers, (answer) => {
-          if (answer.type === MUTUALLY_EXCLUSIVE) {
-            answer.id = `${answer.id}-exclusive`;
-          }
-        })
-      )
-    )
-  );
 };
 
 const buildAnswerObject = (
@@ -93,8 +78,6 @@ const buildAnswerObject = (
   }
 
   if (right.type === "SelectedOptions") {
-    mutuallyExclusiveId(left, right, ctx);
-
     const optionValues = [
       condition !== authorConditions.UNANSWERED
         ? getOptionValues(right.optionIds, ctx.questionnaireJson)

--- a/src/eq_schema/schema/Question/index.js
+++ b/src/eq_schema/schema/Question/index.js
@@ -187,13 +187,11 @@ class Question {
         );
         const tempAnswer = {
           ...answer,
-          id: this.buildMutuallyExclusiveId(answer.id),
           type: "Checkbox",
         };
         tempAnswer.options[0].qCode = answer.qCode;
         delete tempAnswer.qCode;
         mutuallyExclusiveAnswer = new Answer(tempAnswer);
-        // console.log(mutuallyExclusiveAnswer.id)
       } else if (
         answer.type === MUTUALLY_EXCLUSIVE &&
         answer.options.length > 1
@@ -203,7 +201,6 @@ class Question {
         );
         mutuallyExclusiveAnswer = new Answer({
           ...answer,
-          id: this.buildMutuallyExclusiveId(answer.id),
           type: "Radio",
         });
       } else {
@@ -212,28 +209,6 @@ class Question {
     });
 
     return concat(this.buildAnswers(answers, ctx), mutuallyExclusiveAnswer);
-  }
-
-  //This function fixes the bug where -exclusive gets appended multiple times to the end of an answer id
-  //If there are multiple -exclusive it will keep removing the extra -exclusive until there is only 1 left on the end of the answer id and then it exits the loop
-  //Otherwise, if there is no -exclusive at the end of the answer id it will add one on 
-
-  buildMutuallyExclusiveId(answerId) {
-    let looping = true;
-    while (looping) {
-      if (answerId.endsWith("-exclusive-exclusive")) {
-        answerId = answerId.slice(0, -10);
-      } else if (
-        answerId.endsWith("-exclusive") &&
-        !answerId.endsWith("-exclusive-exclusive")
-      ) {
-        looping = false;
-        return answerId;
-      } else {
-        looping = false;
-        return `${answerId}-exclusive`;
-      }
-    }
   }
 
   buildCalculation(totalValidation, answers, ctx) {

--- a/src/eq_schema/schema/Question/index.js
+++ b/src/eq_schema/schema/Question/index.js
@@ -214,18 +214,24 @@ class Question {
     return concat(this.buildAnswers(answers, ctx), mutuallyExclusiveAnswer);
   }
 
+  //This function fixes the bug where -exclusive gets appended multiple times to the end of an answer id
+  //If there are multiple -exclusive it will keep removing the extra -exclusive until there is only 1 left on the end of the answer id and then it exits the loop
+  //Otherwise, if there is no -exclusive at the end of the answer id it will add one on 
+
   buildMutuallyExclusiveId(answerId) {
     let looping = true;
     while (looping) {
       if (answerId.endsWith("-exclusive-exclusive")) {
         answerId = answerId.slice(0, -10);
-      } else if (answerId.endsWith("-exclusive") && !(answerId.endsWith("-exclusive-exclusive"))) {
-          looping = false
-          return answerId
-      }
-      else {
+      } else if (
+        answerId.endsWith("-exclusive") &&
+        !answerId.endsWith("-exclusive-exclusive")
+      ) {
         looping = false;
-        return `${answerId}-exclusive`
+        return answerId;
+      } else {
+        looping = false;
+        return `${answerId}-exclusive`;
       }
     }
   }

--- a/src/eq_schema/schema/Question/index.js
+++ b/src/eq_schema/schema/Question/index.js
@@ -9,7 +9,7 @@ const {
 } = require("../../../utils/compoundFunctions");
 
 const Answer = require("../Answer");
-const { getValueSource } = require("../../builders/valueSource")
+const { getValueSource } = require("../../builders/valueSource");
 
 const {
   DATE,
@@ -105,9 +105,19 @@ class Question {
       this.calculations = question.totalValidation.allowUnanswered
         ? [
             this.buildUnansweredCalculation(question.answers),
-            this.buildCalculation(question.totalValidation, question.answers, ctx),
+            this.buildCalculation(
+              question.totalValidation,
+              question.answers,
+              ctx
+            ),
           ]
-        : [this.buildCalculation(question.totalValidation, question.answers, ctx)];
+        : [
+            this.buildCalculation(
+              question.totalValidation,
+              question.answers,
+              ctx
+            ),
+          ];
     } else {
       this.type = "General";
       this.answers = this.buildAnswers(question.answers, ctx);
@@ -170,20 +180,20 @@ class Question {
     let mutuallyExclusiveAnswer;
     answers.forEach((answer) => {
       answer.properties.required = false;
-      if (answer.type === MUTUALLY_EXCLUSIVE && answer.options.length === 1) {
 
+      if (answer.type === MUTUALLY_EXCLUSIVE && answer.options.length === 1) {
         answers = answers.filter(
           (answer) => answer.type !== MUTUALLY_EXCLUSIVE
         );
         const tempAnswer = {
           ...answer,
-          id: `${answer.id}-exclusive`,
+          id: this.buildMutuallyExclusiveId(answer.id),
           type: "Checkbox",
-        }
-        tempAnswer.options[0].qCode = answer.qCode
-        delete tempAnswer.qCode
+        };
+        tempAnswer.options[0].qCode = answer.qCode;
+        delete tempAnswer.qCode;
         mutuallyExclusiveAnswer = new Answer(tempAnswer);
-
+        // console.log(mutuallyExclusiveAnswer.id)
       } else if (
         answer.type === MUTUALLY_EXCLUSIVE &&
         answer.options.length > 1
@@ -193,7 +203,7 @@ class Question {
         );
         mutuallyExclusiveAnswer = new Answer({
           ...answer,
-          id: `${answer.id}-exclusive`,
+          id: this.buildMutuallyExclusiveId(answer.id),
           type: "Radio",
         });
       } else {
@@ -202,6 +212,18 @@ class Question {
     });
 
     return concat(this.buildAnswers(answers, ctx), mutuallyExclusiveAnswer);
+  }
+
+  buildMutuallyExclusiveId(answerId) {
+    let looping = true;
+    while (looping) {
+      if (answerId.endsWith("-exclusive-exclusive")) {
+        answerId = answerId.slice(0, -10);
+      } else {
+        looping = false;
+        return answerId;
+      }
+    }
   }
 
   buildCalculation(totalValidation, answers, ctx) {
@@ -220,7 +242,7 @@ class Question {
     const rightSide =
       totalValidation.entityType === "Custom"
         ? { value: totalValidation.custom }
-        : { value: getValueSource(ctx, totalValidation.previousAnswer)} ;
+        : { value: getValueSource(ctx, totalValidation.previousAnswer) };
 
     return {
       calculation_type: "sum",

--- a/src/eq_schema/schema/Question/index.js
+++ b/src/eq_schema/schema/Question/index.js
@@ -219,9 +219,13 @@ class Question {
     while (looping) {
       if (answerId.endsWith("-exclusive-exclusive")) {
         answerId = answerId.slice(0, -10);
-      } else {
+      } else if (answerId.endsWith("-exclusive") && !(answerId.endsWith("-exclusive-exclusive"))) {
+          looping = false
+          return answerId
+      }
+      else {
         looping = false;
-        return answerId;
+        return `${answerId}-exclusive`
       }
     }
   }

--- a/src/eq_schema/schema/Question/index.test.js
+++ b/src/eq_schema/schema/Question/index.test.js
@@ -751,7 +751,7 @@ describe("Question", () => {
     it("should have unique answer id for the last answer", () => {
       const question = new Question(createQuestionJSON({ answers }));
       expect(last(question.answers)).toMatchObject({
-        id: "answer2-exclusive",
+        id: "answer2",
       });
     });
 


### PR DESCRIPTION
ticket: https://jira.ons.gov.uk/browse/EAR-1898

This PR removes all '-exclusive' from mutually exclusive answer IDs as they are no longer needed

- Create a questionnaire with checkbox answers
- Add an other option to the checkbox answer
- Add Or answer type below the checkbox answer
- Add another question and include routing that uses the above check box
- Then use the convert to check if the answer ID's only have no exclusive.
- Add piping that uses an exclusive answer, check that the piping is pointing to the correct answer