### PR TITLE
EAR 1883 Add metadata logic

### DIFF
--- a/src/eq_schema/builders/basicQuestionnaireJSON.js
+++ b/src/eq_schema/builders/basicQuestionnaireJSON.js
@@ -2,6 +2,15 @@ const questionnaireJson = {
   id: "1",
   title: "Basic Questionnaire JSON",
   summary: false,
+  metadata: [
+    {
+      id: "metadata-1",
+      key: "ru_name",
+      alias: "Ru Name",
+      type: "Text",
+      textValue: "ESSENTIAL ENTERPRISE LTD.",
+    },
+  ],
   sections: [
     {
       id: "1",
@@ -21,9 +30,9 @@ const questionnaireJson = {
                 {
                   id: "1",
                   type: "Currency",
-                  label: "Answer 1"
-                }
-              ]
+                  label: "Answer 1",
+                },
+              ],
             },
             {
               id: "2",
@@ -35,13 +44,13 @@ const questionnaireJson = {
                 {
                   id: "2",
                   type: "Number",
-                  label: "Answer 2"
-                }
-              ]
-            }
-          ]
-        }
-      ]
+                  label: "Answer 2",
+                },
+              ],
+            },
+          ],
+        },
+      ],
     },
     {
       id: "2",
@@ -61,7 +70,7 @@ const questionnaireJson = {
                 {
                   id: "3",
                   type: "Number",
-                  label: "Answer 3"
+                  label: "Answer 3",
                 },
                 {
                   id: "4",
@@ -74,16 +83,16 @@ const questionnaireJson = {
                     {
                       id: "456",
                       label: "white",
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
 };
 
 const questionnaireJsonWithSummary = {

--- a/src/eq_schema/builders/routing2/newRoutingDestination/index.js
+++ b/src/eq_schema/builders/routing2/newRoutingDestination/index.js
@@ -1,4 +1,8 @@
 const routingConditionConversion = require("../../../../utils/routingConditionConversion");
+const {
+  getMetadataKey,
+} = require("../../../../utils/contentUtils/getMetadataKey");
+
 const { flatMap, filter } = require("lodash");
 
 const authorConditions = {
@@ -33,6 +37,10 @@ const checkType = (type) => {
 
   if (type === "Answer") {
     return "answers";
+  }
+
+  if (type === "Metadata") {
+    return "metadata";
   }
 
   return null;
@@ -126,9 +134,23 @@ const buildAnswerObject = (
   return finalVal;
 };
 
+const buildMetadataObject = (expression, ctx) => {
+  const { condition, left, right } = expression;
+  const returnValue = [
+    {
+      source: checkType(left.type),
+      identifier: getMetadataKey(ctx, left.metadataId),
+    },
+    right.customValue.text,
+  ];
+  return { [routingConditionConversion(condition)]: returnValue };
+};
+
 const checkValidRoutingType = (expression, ctx) => {
   if (expression.left.type === "Answer") {
     return buildAnswerObject(expression, ctx);
+  } else if (expression.left.type === "Metadata") {
+    return buildMetadataObject(expression, ctx);
   } else {
     throw new Error(
       `${expression.left.type} is not a valid routing answer type`

--- a/src/eq_schema/builders/routing2/newRoutingDestination/index.test.js
+++ b/src/eq_schema/builders/routing2/newRoutingDestination/index.test.js
@@ -3,177 +3,214 @@ const { questionnaireJson } = require("../../basicQuestionnaireJSON");
 const checkValidRoutingType = require(".");
 
 describe("Should build a runner representation of a binary expression", () => {
-  it("should throw on unsupported answer type", () => {
-    const expression = {
-      left: {
-        id: "1",
-        type: "Text",
-      },
-      condition: "Equal",
-      right: {
-        number: 5,
-      },
-    };
-
-    expect(() =>
-      checkValidRoutingType(expression, { questionnaireJson })
-    ).toThrow("not a valid routing answer type");
-  });
-  describe("With Radio answers", () => {
-    const buildBinaryExpression = (optionIds, condition) => ({
-      left: {
-        answerId: "1",
-        type: "Answer",
-      },
-      condition,
-      right: {
-        type: "SelectedOptions",
-        optionIds,
-      },
-    });
-
-    it("With a radio answer and single selected option", () => {
-      const expression = buildBinaryExpression(["123"], "OneOf");
-      const runnerExpression = checkValidRoutingType(expression, {
-        questionnaireJson,
-      });
-
-      expect(runnerExpression).toMatchObject({
-        "in": [
-          {
-            identifier: "answer1",
-            source: "answers",
-          },
-          ["red"],
-        ],
-      });
-    });
-
-    it("With a radio answer and no selected options", () => {
-      const expression = buildBinaryExpression(["123", "456"], "Unanswered");
-      const runnerExpression = checkValidRoutingType(expression, {
-        questionnaireJson,
-      });
-
-      expect(runnerExpression).toMatchObject({
-        "==": [
-          null,
-          {
-            identifier: "answer1",
-            source: "answers",
-          },
-        ],
-      });
-    });
-
-    it("With a radio answer and multiple selected options", () => {
-      const expression = buildBinaryExpression(["123", "456"], "OneOf");
-
-      const runnerExpression = checkValidRoutingType(expression, {
-        questionnaireJson,
-      });
-      expect(runnerExpression).toMatchObject({
-        "in": [
-          {
-            identifier: "answer1",
-            source: "answers",
-          },
-          ["red", "white"],
-        ],
-      });
-    });
-  });
-
-  describe("With Number based answers", () => {
-    it("supports a custom value", () => {
+  describe("With answers", () => {
+    it("should throw on unsupported answer type", () => {
       const expression = {
         left: {
-          answerId: "1",
-          type: "Answer",
+          id: "1",
+          type: "Text",
         },
         condition: "Equal",
         right: {
-          customValue: {
-            number: 5,
-          },
+          number: 5,
         },
       };
-      const runnerExpression = checkValidRoutingType(expression, {
-        questionnaireJson,
-      });
-      expect(runnerExpression).toMatchObject({
-        "==": [
-          {
-            identifier: "answer1",
-            source: "answers",
-          },
-          5,
-        ],
-      });
+
+      expect(() =>
+        checkValidRoutingType(expression, { questionnaireJson })
+      ).toThrow("not a valid routing answer type");
     });
 
-    it("Checks that even though there's a number value stored on the right handside, the condition is unanswered, meaning the value should be null on the object", () => {
-      const expression = {
+    describe("With Radio answers", () => {
+      const buildBinaryExpression = (optionIds, condition) => ({
         left: {
           answerId: "1",
           type: "Answer",
         },
-        condition: "Unanswered",
+        condition,
         right: {
-          customValue: {
-            number: 5,
-          },
+          type: "SelectedOptions",
+          optionIds,
         },
-      };
-
-      const runnerExpression = checkValidRoutingType(expression, {
-        questionnaireJson,
       });
 
-      expect(runnerExpression).toMatchObject({
-        "==": [
-          {
-            identifier: "answer1",
-            source: "answers",
+      it("With a radio answer and single selected option", () => {
+        const expression = buildBinaryExpression(["123"], "OneOf");
+        const runnerExpression = checkValidRoutingType(expression, {
+          questionnaireJson,
+        });
+
+        expect(runnerExpression).toMatchObject({
+          in: [
+            {
+              identifier: "answer1",
+              source: "answers",
+            },
+            ["red"],
+          ],
+        });
+      });
+
+      it("With a radio answer and no selected options", () => {
+        const expression = buildBinaryExpression(["123", "456"], "Unanswered");
+        const runnerExpression = checkValidRoutingType(expression, {
+          questionnaireJson,
+        });
+
+        expect(runnerExpression).toMatchObject({
+          "==": [
+            null,
+            {
+              identifier: "answer1",
+              source: "answers",
+            },
+          ],
+        });
+      });
+
+      it("With a radio answer and multiple selected options", () => {
+        const expression = buildBinaryExpression(["123", "456"], "OneOf");
+
+        const runnerExpression = checkValidRoutingType(expression, {
+          questionnaireJson,
+        });
+        expect(runnerExpression).toMatchObject({
+          in: [
+            {
+              identifier: "answer1",
+              source: "answers",
+            },
+            ["red", "white"],
+          ],
+        });
+      });
+    });
+
+    describe("With Number based answers", () => {
+      it("supports a custom value", () => {
+        const expression = {
+          left: {
+            answerId: "1",
+            type: "Answer",
           },
-          null,
-        ],
+          condition: "Equal",
+          right: {
+            customValue: {
+              number: 5,
+            },
+          },
+        };
+        const runnerExpression = checkValidRoutingType(expression, {
+          questionnaireJson,
+        });
+        expect(runnerExpression).toMatchObject({
+          "==": [
+            {
+              identifier: "answer1",
+              source: "answers",
+            },
+            5,
+          ],
+        });
+      });
+
+      it("Checks that even though there's a number value stored on the right handside, the condition is unanswered, meaning the value should be null on the object", () => {
+        const expression = {
+          left: {
+            answerId: "1",
+            type: "Answer",
+          },
+          condition: "Unanswered",
+          right: {
+            customValue: {
+              number: 5,
+            },
+          },
+        };
+
+        const runnerExpression = checkValidRoutingType(expression, {
+          questionnaireJson,
+        });
+
+        expect(runnerExpression).toMatchObject({
+          "==": [
+            {
+              identifier: "answer1",
+              source: "answers",
+            },
+            null,
+          ],
+        });
+      });
+    });
+
+    describe("With checkbox answers", () => {
+      it("Excepts a checkbox count of answer and returns the correct object", () => {
+        const expression = {
+          secondaryCondition: "Equal",
+          left: {
+            answerId: "1",
+            type: "Answer",
+          },
+          condition: "CountOf",
+          right: {
+            customValue: {
+              number: 5,
+            },
+          },
+        };
+
+        const runnerExpression = checkValidRoutingType(expression, {
+          questionnaireJson,
+        });
+
+        expect(runnerExpression).toMatchObject({
+          "==": [
+            {
+              count: [
+                {
+                  source: "answers",
+                  identifier: "answer1",
+                },
+              ],
+            },
+            5,
+          ],
+        });
       });
     });
   });
 
-  describe("With checkbox answers", () => {
-    it("Excepts a checkbox count of answer and returns the correct object", () => {
-      const expression = {
-        secondaryCondition: "Equal",
-        left: {
-          answerId: "1",
-          type: "Answer",
-        },
-        condition: "CountOf",
-        right: {
-          customValue: {
-            number: 5,
+  describe("With metadata", () => {
+    describe("Text metadata", () => {
+      it("should return correct metadata object for text metadata", () => {
+        const expression = {
+          left: {
+            metadataId: "metadata-1",
+            type: "Metadata",
           },
-        },
-      };
-
-      const runnerExpression = checkValidRoutingType(expression, {
-        questionnaireJson,
-      });
-
-      expect(runnerExpression).toMatchObject({
-        "==": [
-          {
-            count: [
-              {
-                source: "answers",
-                identifier: "answer1",
-              },
-            ],
+          condition: "Matches",
+          right: {
+            type: "Custom",
+            customValue: {
+              text: "Test text",
+            },
           },
-          5,
-        ],
+        };
+
+        const runnerExpression = checkValidRoutingType(expression, {
+          questionnaireJson,
+        });
+
+        expect(runnerExpression).toMatchObject({
+          "==": [
+            {
+              source: "metadata",
+              identifier: "ru_name",
+            },
+            "Test text",
+          ],
+        });
       });
     });
   });

--- a/src/utils/contentUtils/getMetadataKey.js
+++ b/src/utils/contentUtils/getMetadataKey.js
@@ -1,0 +1,11 @@
+const { find } = require("lodash");
+
+const getMetadataKey = (ctx, metadataId) => {
+  const metadata = find(ctx.questionnaireJson.metadata, { id: metadataId });
+  if (metadata) {
+    return metadata.key;
+  }
+  return null;
+};
+
+module.exports = { getMetadataKey };

--- a/src/utils/contentUtils/getMetadataKey.test.js
+++ b/src/utils/contentUtils/getMetadataKey.test.js
@@ -1,0 +1,19 @@
+const { getMetadataKey } = require("./getMetadataKey");
+const {
+  questionnaireJson,
+} = require("../../eq_schema/builders/basicQuestionnaireJSON");
+
+describe("getMetadataKey", () => {
+  let ctx = {};
+  ctx.questionnaireJson = questionnaireJson;
+
+  it("should return metadata key for valid metadataId", () => {
+    const metadataKey = getMetadataKey(ctx, "metadata-1");
+    expect(metadataKey).toBe("ru_name");
+  });
+
+  it("should return null for invalid metadataId", () => {
+    const metadataKey = getMetadataKey(ctx, "not-metadata-1");
+    expect(metadataKey).toBeNull();
+  });
+});

--- a/src/utils/routingConditionConversion/index.js
+++ b/src/utils/routingConditionConversion/index.js
@@ -10,6 +10,7 @@ const routingConditionConversions = {
   NotAnyOf: "not",
   Unanswered: "==",
   OneOf: "in",
+  Matches: "==",
 };
 
 const routingConditionConversion = (conditionString) => {


### PR DESCRIPTION
### What is the context of this PR?

**Author PR** - https://github.com/ONSdigital/eq-author-app/pull/2839

Allows logic to be applied based on metadata values - this includes routing logic, skip logic and display logic
https://jira.ons.gov.uk/browse/EAR-1883

### How to review

**Check:**
- [ ] When completing a questionnaire, when logic is applied based on metadata values, the logic is applied correctly and routes to the correct destination
- [ ] When completing a questionnaire, when logic is applied based on metadata values, if the question's metadata logic condition is not met, the logic routes to the correct destination
- [ ] When completing a questionnaire, when logic is applied based on answer values, the logic is applied correctly and routes to the correct destination
- [ ] When completing a questionnaire, when logic is applied based on answer values, if the question's answer logic condition is not met, the logic routes to the correct destination