### PR TITLE
Ear 1947 data version

### DIFF
--- a/src/eq_schema/schema/Answer/index.js
+++ b/src/eq_schema/schema/Answer/index.js
@@ -48,8 +48,8 @@ class Answer {
     if (answer.qCode) {
       if (
         !ctx ||
-        ctx.questionnaireJson.dataVersionThree ||
-        (!ctx.questionnaireJson.dataVersionThree && answer.type !== CHECKBOX)
+        ctx.questionnaireJson.dataVersion === "3" ||
+        (ctx.questionnaireJson.dataVersion !== "3" && answer.type !== CHECKBOX)
       ) {
         this.q_code = answer.qCode;
       }
@@ -257,8 +257,8 @@ class Answer {
     if (q_code) {
       if (
         !ctx ||
-        !ctx.questionnaireJson.dataVersionThree ||
-        (ctx.questionnaireJson.dataVersionThree && type !== CHECKBOX)
+        ctx.questionnaireJson.dataVersion !== "3" ||
+        (ctx.questionnaireJson.dataVersion === 3 && type !== CHECKBOX)
       ) {
         option.q_code = q_code;
       }

--- a/src/eq_schema/schema/Answer/index.js
+++ b/src/eq_schema/schema/Answer/index.js
@@ -255,11 +255,7 @@ class Answer {
     };
 
     if (q_code) {
-      if (
-        !ctx ||
-        ctx.questionnaireJson.dataVersion !== "3" ||
-        (ctx.questionnaireJson.dataVersion === 3 && type !== CHECKBOX)
-      ) {
+      if (!ctx || ctx.questionnaireJson.dataVersion !== "3") {
         option.q_code = q_code;
       }
     }

--- a/src/eq_schema/schema/Answer/index.js
+++ b/src/eq_schema/schema/Answer/index.js
@@ -46,7 +46,12 @@ class Answer {
     }
 
     if (answer.qCode) {
-      this.q_code = answer.qCode;
+      if (
+        ctx.questionnaireJson.dataVersionThree ||
+        (!ctx.questionnaireJson.dataVersionThree && answer.type !== CHECKBOX)
+      ) {
+        this.q_code = answer.qCode;
+      }
     }
 
     if (answer.type === UNIT) {
@@ -249,7 +254,12 @@ class Answer {
     };
 
     if (q_code) {
-      option.q_code = q_code;
+      if (
+        !ctx.questionnaireJson.dataVersionThree ||
+        (ctx.questionnaireJson.dataVersionThree && type !== CHECKBOX)
+      ) {
+        option.q_code = q_code;
+      }
     }
 
     if (description) {

--- a/src/eq_schema/schema/Answer/index.js
+++ b/src/eq_schema/schema/Answer/index.js
@@ -47,6 +47,7 @@ class Answer {
 
     if (answer.qCode) {
       if (
+        !ctx ||
         ctx.questionnaireJson.dataVersionThree ||
         (!ctx.questionnaireJson.dataVersionThree && answer.type !== CHECKBOX)
       ) {
@@ -255,6 +256,7 @@ class Answer {
 
     if (q_code) {
       if (
+        !ctx ||
         !ctx.questionnaireJson.dataVersionThree ||
         (ctx.questionnaireJson.dataVersionThree && type !== CHECKBOX)
       ) {

--- a/src/eq_schema/schema/Answer/index.test.js
+++ b/src/eq_schema/schema/Answer/index.test.js
@@ -33,8 +33,9 @@ describe("Answer", () => {
     ...answer,
   });
 
-  const createContextJSON = () => ({
+  const createContextJSON = (args) => ({
     questionnaireJson: {
+      dataVersion: "1",
       metadata: [
         {
           id: "test_ref",
@@ -63,6 +64,7 @@ describe("Answer", () => {
           ],
         },
       ],
+      ...args,
     },
   });
 
@@ -1038,6 +1040,89 @@ describe("Answer", () => {
     );
     expect(answer.options[0].q_code).toBe("1");
     expect(answer.options[1].q_code).toBe("2");
+  });
+
+  describe("Data version", () => {
+    it("should contain a qCode if data version is not 3 and type is checkbox option", () => {
+      const answer = new Answer(
+        createAnswerJSON({
+          type: CHECKBOX,
+          qCode: "answer-1",
+          options: [
+            {
+              id: 1,
+              label: "Option one",
+              description: null,
+              qCode: "option-1",
+            },
+            {
+              id: 2,
+              label: "Option two",
+              description: null,
+              qCode: "option-2",
+            },
+          ],
+        }),
+        createContextJSON()
+      );
+      expect(answer.q_code).toBeUndefined();
+      expect(answer.options[0].q_code).toBe("option-1");
+      expect(answer.options[1].q_code).toBe("option-2");
+    });
+
+    it("should contain a qCode if data version is 3 and type is checkbox answer", () => {
+      const answer = new Answer(
+        createAnswerJSON({
+          type: CHECKBOX,
+          qCode: "answer-1",
+          options: [
+            {
+              id: 1,
+              label: "Option one",
+              description: null,
+              qCode: "option-1",
+            },
+            {
+              id: 2,
+              label: "Option two",
+              description: null,
+              qCode: "option-2",
+            },
+          ],
+        }),
+        createContextJSON({ dataVersion: "3" })
+      );
+      expect(answer.q_code).toBe("answer-1");
+      expect(answer.options[0].q_code).toBeUndefined();
+      expect(answer.options[1].q_code).toBeUndefined();
+    });
+
+    it("should contain a qCode if data version is 3 and type is radio answer", () => {
+      const answer = new Answer(
+        createAnswerJSON({
+          type: CHECKBOX,
+          qCode: "answer-1",
+          options: [
+            {
+              id: 1,
+              label: "Option one",
+              description: null,
+              qCode: "option-1",
+            },
+            {
+              id: 2,
+              label: "Option two",
+              description: null,
+              qCode: "option-2",
+            },
+          ],
+        }),
+        createContextJSON({ dataVersion: "3" })
+      );
+      expect(answer.q_code).toBe("answer-1");
+      expect(answer.options[0].q_code).toBeUndefined();
+      expect(answer.options[1].q_code).toBeUndefined();
+    });
   });
 
   describe("creating checkbox/radio answers with additionalAnswers", () => {

--- a/src/eq_schema/schema/Questionnaire/index.js
+++ b/src/eq_schema/schema/Questionnaire/index.js
@@ -37,7 +37,7 @@ class Questionnaire {
     this.language = "en";
     this.mime_type = "application/json/ons/eq";
     this.schema_version = "0.0.1";
-    this.data_version = "0.0.1";
+    this.data_version = questionnaireJson.dataVersionThree ? "0.0.3" : "0.0.1";
 
     this.survey_id = surveyId || "zzz";
     this.form_type = formType || "9999";

--- a/src/eq_schema/schema/Questionnaire/index.js
+++ b/src/eq_schema/schema/Questionnaire/index.js
@@ -37,7 +37,8 @@ class Questionnaire {
     this.language = "en";
     this.mime_type = "application/json/ons/eq";
     this.schema_version = "0.0.1";
-    this.data_version = questionnaireJson.dataVersionThree ? "0.0.3" : "0.0.1";
+    this.data_version =
+      questionnaireJson.dataVersion === "3" ? "0.0.3" : "0.0.1";
 
     this.survey_id = surveyId || "zzz";
     this.form_type = formType || "9999";

--- a/src/eq_schema/schema/Questionnaire/index.test.js
+++ b/src/eq_schema/schema/Questionnaire/index.test.js
@@ -17,6 +17,7 @@ describe("Questionnaire", () => {
         summary: true,
         hub: false,
         surveyId: "123",
+        dataVersion: 1,
         themeSettings: {
           id: "1",
           previewTheme: "default",
@@ -80,6 +81,21 @@ describe("Questionnaire", () => {
   it("should include survey_id", () => {
     expect(questionnaire).toMatchObject({
       survey_id: "123",
+    });
+  });
+
+  it("should set data_version to 0.0.1 when questionnaireJson dataVersion is not 3", () => {
+    expect(questionnaire).toMatchObject({
+      data_version: "0.0.1",
+    });
+  });
+
+  it("should set data_version to 0.0.3 when questionnaireJson dataVersion is 3", () => {
+    const questionnaire = new Questionnaire(
+      createQuestionnaireJSON({ dataVersion: "3" })
+    );
+    expect(questionnaire).toMatchObject({
+      data_version: "0.0.3",
     });
   });
 


### PR DESCRIPTION
### What is the context of this PR?

https://jira.ons.gov.uk/browse/EAR-1947

Author: https://github.com/ONSdigital/eq-author-app/pull/2862

Set questionnaire data_version depending on Author questionnaire schema's dataVersion value

When Author dataVersion is "1", data_version should be "0.0.1"
When Author dataVersion is "3", data_version should be "0.0.3"

When a questionnaire's data version is 0.0.1, the Runner questionnaire schema should output QCodes for checkbox options and not for checkbox answers, even if a checkbox answer includes a QCode in the Author questionnaire schema
When a questionnaire's data version is 0.0.3, the Runner questionnaire schema should output QCodes for the checkbox answer and not for any of the checkbox's options, even if a checkbox options include QCodes in the Author questionnaire schema

### How to review

View questionnaire Runner schema

**Check:**
- [ ] data_version is set to 0.0.1 when Author questionnaire dataVersion is "1"
- [ ] data_version is set to 0.0.3 when Author questionnaire dataVersion is "3"
- [ ] When a questionnaire's data version is 1, QCodes are assigned to checkbox options and not to checkbox answers, even if the checkbox answer includes a QCode in the Author questionnaire schema
- [ ] When a questionnaire's data version is 3, QCodes are assigned to checkbox answers and not to checkbox options, even if the checkbox options include a QCode in the Author questionnaire schema
- [ ] Completing a questionnaire with checkbox answers does not display any errors if the correct QCodes have been input - check for both data version 3 and data version 1
