### PR TITLE
EAR 1990 Add driving and repeating question answer codes

### DIFF
--- a/src/utils/createAnswerCodes/index.js
+++ b/src/utils/createAnswerCodes/index.js
@@ -30,7 +30,7 @@ const getAllAnswers = (questionnaireJson) => {
   return allQuestionnaireAnswers;
 };
 
-// Get all pages in the questionnaire
+// Get all list collector pages in the questionnaire
 const getAllListCollectorPages = (questionnaireJson) => {
   const allQuestionnaireListPages = [];
   questionnaireJson.sections.forEach((section) => {
@@ -87,6 +87,7 @@ const createAnswerCodes = (questionnaireJson) => {
     }
   });
 
+  // Add answer codes for list collector driving and repeating questions
   listCollectorPages.forEach((page) => {
     answerCodes.push(
       {

--- a/src/utils/createAnswerCodes/index.js
+++ b/src/utils/createAnswerCodes/index.js
@@ -91,11 +91,11 @@ const createAnswerCodes = (questionnaireJson) => {
   listCollectorPages.forEach((page) => {
     answerCodes.push(
       {
-        answer_id: `answer${page.drivingId}`,
+        answer_id: `answer-driving-${page.id}`,
         code: page.drivingQCode,
       },
       {
-        answer_id: `answer${page.anotherId}`,
+        answer_id: `add-another-${page.id}`,
         code: page.anotherQCode,
       }
     );

--- a/src/utils/createAnswerCodes/index.js
+++ b/src/utils/createAnswerCodes/index.js
@@ -30,10 +30,27 @@ const getAllAnswers = (questionnaireJson) => {
   return allQuestionnaireAnswers;
 };
 
+// Get all pages in the questionnaire
+const getAllListCollectorPages = (questionnaireJson) => {
+  const allQuestionnaireListPages = [];
+  questionnaireJson.sections.forEach((section) => {
+    section.folders.forEach((folder) => {
+      folder.pages.forEach((page) => {
+        if (page.pageType === "ListCollectorPage") {
+          allQuestionnaireListPages.push(page);
+        }
+      });
+    });
+  });
+
+  return allQuestionnaireListPages;
+};
+
 // Generates answer codes for all answers
 const createAnswerCodes = (questionnaireJson) => {
   const answerCodes = [];
   const answers = getAllAnswers(questionnaireJson);
+  const listCollectorPages = getAllListCollectorPages(questionnaireJson);
 
   // Loop through all answers in the questionnaire
   answers.forEach((answer) => {
@@ -68,6 +85,19 @@ const createAnswerCodes = (questionnaireJson) => {
         });
       }
     }
+  });
+
+  listCollectorPages.forEach((page) => {
+    answerCodes.push(
+      {
+        answer_id: `answer${page.drivingId}`,
+        code: page.drivingQCode,
+      },
+      {
+        answer_id: `answer${page.anotherId}`,
+        code: page.anotherQCode,
+      }
+    );
   });
 
   return answerCodes;

--- a/src/utils/createAnswerCodes/index.test.js
+++ b/src/utils/createAnswerCodes/index.test.js
@@ -36,20 +36,8 @@ describe("Create answer codes", () => {
                   id: "page-1",
                   title: "Question 1",
                   pageType,
-                  drivingId: pageType === "ListCollectorPage" && "driving-id",
-                  drivingQuestion:
-                    pageType === "ListCollectorPage" &&
-                    "Driving question title",
-                  drivingPositive: pageType === "ListCollectorPage" && "Yes",
-                  drivingNegative: pageType === "ListCollectorPage" && "No",
                   drivingQCode:
                     pageType === "ListCollectorPage" && "driving-code",
-                  anotherId: pageType === "ListCollectorPage" && "another-id",
-                  anotherTitle:
-                    pageType === "ListCollectorPage" &&
-                    "Another question title",
-                  anotherPositive: pageType === "ListCollectorPage" && "Yes",
-                  anotherNegative: pageType === "ListCollectorPage" && "No",
                   anotherQCode:
                     pageType === "ListCollectorPage" && "another-code",
                   answers: [
@@ -480,11 +468,11 @@ describe("Create answer codes", () => {
           code: "list-textfield-answer-code",
         },
         {
-          answer_id: "answerdriving-id",
+          answer_id: "answer-driving-page-1",
           code: "driving-code",
         },
         {
-          answer_id: "answeranother-id",
+          answer_id: "add-another-page-1",
           code: "another-code",
         },
       ]);

--- a/src/utils/createAnswerCodes/index.test.js
+++ b/src/utils/createAnswerCodes/index.test.js
@@ -36,6 +36,22 @@ describe("Create answer codes", () => {
                   id: "page-1",
                   title: "Question 1",
                   pageType,
+                  drivingId: pageType === "ListCollectorPage" && "driving-id",
+                  drivingQuestion:
+                    pageType === "ListCollectorPage" &&
+                    "Driving question title",
+                  drivingPositive: pageType === "ListCollectorPage" && "Yes",
+                  drivingNegative: pageType === "ListCollectorPage" && "No",
+                  drivingQCode:
+                    pageType === "ListCollectorPage" && "driving-code",
+                  anotherId: pageType === "ListCollectorPage" && "another-id",
+                  anotherTitle:
+                    pageType === "ListCollectorPage" &&
+                    "Another question title",
+                  anotherPositive: pageType === "ListCollectorPage" && "Yes",
+                  anotherNegative: pageType === "ListCollectorPage" && "No",
+                  anotherQCode:
+                    pageType === "ListCollectorPage" && "another-code",
                   answers: [
                     {
                       ...answer,
@@ -444,7 +460,7 @@ describe("Create answer codes", () => {
   });
 
   describe("Page types", () => {
-    it("shoul add answer codes for list collector page type", () => {
+    it("should add answer codes for list collector page type", () => {
       const answer = {
         id: "list-textfield-answer-1",
         type: TEXTFIELD,
@@ -455,12 +471,21 @@ describe("Create answer codes", () => {
         answer,
         "ListCollectorPage"
       );
+
       const answerCodes = createAnswerCodes(questionnaire);
 
       expect(answerCodes).toEqual([
         {
           answer_id: "answerlist-textfield-answer-1",
           code: "list-textfield-answer-code",
+        },
+        {
+          answer_id: "answerdriving-id",
+          code: "driving-code",
+        },
+        {
+          answer_id: "answeranother-id",
+          code: "another-code",
         },
       ]);
     });


### PR DESCRIPTION
### What is the context of this PR?

Add answer codes for list collector driving and repeating questions

**Author PR:** https://github.com/ONSdigital/eq-author-app/pull/2904

https://jira.ons.gov.uk/browse/EAR-1990

### How to review

Create a collection list and a list collector page in Author

**Check:**
- [ ] `answer_codes` includes an `answer_id` and `answer_code` for driving questions - the `answer_id` should match the driving answer's ID value in the schema, and the `answer_code` should be from `drivingQCode`
- [ ] `answer_codes` includes an `answer_id` and `answer_code` for repeating questions - the `answer_id` should match the repeating answer's ID value in the schema, and the `answer_code` should be from `anotherQCode`

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
