### PR TITLE
EAR 2033 and 2035 - section page description redesign

### DIFF
--- a/src/eq_schema/schema/Block/index.js
+++ b/src/eq_schema/schema/Block/index.js
@@ -71,10 +71,17 @@ class Block {
     }
   }
 
-  static buildIntroBlock(introductionTitle, introductionContent, groupId, ctx) {
+  static buildIntroBlock(
+    introductionTitle,
+    introductionContent,
+    introductionPageDescription,
+    groupId,
+    ctx
+  ) {
     return {
       type: "Interstitial",
       id: `group${groupId}-introduction`,
+      page_title: introductionPageDescription,
       content: {
         title: processPipe(ctx)(introductionTitle) || "",
         contents: reversePipe(ctx)(introductionContent).contents,
@@ -90,10 +97,9 @@ class Block {
       this.question = new Question(page, ctx);
     }
     if (page.pageType === "ListCollectorPage") {
-      this.page_title = page.anotherPageDescription
-    }
-    else {
-      this.page_title = page.pageDescription
+      this.page_title = page.anotherPageDescription;
+    } else {
+      this.page_title = page.pageDescription;
     }
     if (page.pageType === "CalculatedSummaryPage") {
       this.title = processPipe(ctx)(page.title);

--- a/src/eq_schema/schema/Block/index.test.js
+++ b/src/eq_schema/schema/Block/index.test.js
@@ -144,6 +144,7 @@ describe("Block", () => {
       const introBlock = Block.buildIntroBlock(
         createPipeInText(),
         "",
+        "",
         0,
         createContext()
       );
@@ -155,6 +156,7 @@ describe("Block", () => {
     it("should handle piped values in title while stripping html", () => {
       const introBlock = Block.buildIntroBlock(
         createPipeInHtml(),
+        "",
         "",
         0,
         createContext()
@@ -169,6 +171,7 @@ describe("Block", () => {
       const introBlock = Block.buildIntroBlock(
         "",
         `<ul>${createPipeInHtml({ element: "li" })}<li>Some Value</li</ul>`,
+        "",
         0,
         createContext()
       );

--- a/src/eq_schema/schema/Section/index.js
+++ b/src/eq_schema/schema/Section/index.js
@@ -3,10 +3,15 @@ const convertPipes = require("../../../utils/convertPipes");
 const { getInnerHTMLWithPiping } = require("../../../utils/HTMLUtils");
 const { flow } = require("lodash/fp");
 const { getText } = require("../../../utils/HTMLUtils");
-const { getList } = require("../../../utils/functions/listGetters")
+const { getList } = require("../../../utils/functions/listGetters");
 const { buildIntroBlock } = require("../Block");
 const { flatMap, filter } = require("lodash");
-const { TEXTFIELD, RADIO, CHECKBOX, SELECT } = require("../../../constants/answerTypes");
+const {
+  TEXTFIELD,
+  RADIO,
+  CHECKBOX,
+  SELECT,
+} = require("../../../constants/answerTypes");
 
 const translateRoutingAndSkipRules = require("../../builders/routing2");
 
@@ -23,18 +28,18 @@ class Section {
       flatMap(folder.pages, (page) =>
         folder.skipConditions
           ? {
-            ...page,
-            skipConditions: [
-              ...folder.skipConditions,
-              ...(page.skipConditions || []),
-            ],
-          }
+              ...page,
+              skipConditions: [
+                ...folder.skipConditions,
+                ...(page.skipConditions || []),
+              ],
+            }
           : page
       )
     );
 
     if (section.repeatingSection) {
-      const list = getList(ctx, section.repeatingSectionListId)
+      const list = getList(ctx, section.repeatingSectionListId);
       this.repeat = {
         for_list: list.listName,
       };
@@ -48,19 +53,19 @@ class Section {
               {
                 arguments: {
                   delimiter: "&nbsp;",
-                  list_to_concatenate: this.buildList(list.answers)
+                  list_to_concatenate: this.buildList(list.answers),
                 },
-                transform: "concatenate_list"
-              }
-            ]
-          }
-        ]
-      }
-    };
+                transform: "concatenate_list",
+              },
+            ],
+          },
+        ],
+      };
+    }
 
     this.summary = {
       show_on_completion: section.sectionSummary || false,
-      page_title: section.pageDescription,
+      page_title: section.sectionSummaryPageDescription,
       collapsible: false,
     };
 
@@ -117,11 +122,13 @@ class Section {
   }
 
   buildList(answers) {
-    return filter(answers, (answer) => [TEXTFIELD, RADIO, CHECKBOX, SELECT].includes(answer.type)).map((answer) => ({
+    return filter(answers, (answer) =>
+      [TEXTFIELD, RADIO, CHECKBOX, SELECT].includes(answer.type)
+    ).map((answer) => ({
       source: "answers",
-      identifier: `answer${answer.id}`
+      identifier: `answer${answer.id}`,
     }));
-  };
+  }
 
   static buildItem(itemId, listCollectorTitle, ctx) {
     const ListCollectorsSummmary = {

--- a/src/eq_schema/schema/Section/index.js
+++ b/src/eq_schema/schema/Section/index.js
@@ -96,7 +96,11 @@ class Section {
 
     this.groups = [new Group({ ...section, pages }, ctx)];
 
-    if (section.introductionTitle && section.introductionContent) {
+    if (
+      section.introductionEnabled &&
+      section.introductionTitle &&
+      section.introductionContent
+    ) {
       // Add introduction page if present
       this.groups[0].blocks.unshift(
         buildIntroBlock(

--- a/src/eq_schema/schema/Section/index.js
+++ b/src/eq_schema/schema/Section/index.js
@@ -99,7 +99,8 @@ class Section {
     if (
       section.introductionEnabled &&
       section.introductionTitle &&
-      section.introductionContent
+      section.introductionContent &&
+      section.introductionPageDescription
     ) {
       // Add introduction page if present
       this.groups[0].blocks.unshift(

--- a/src/eq_schema/schema/Section/index.js
+++ b/src/eq_schema/schema/Section/index.js
@@ -102,6 +102,7 @@ class Section {
         buildIntroBlock(
           section.introductionTitle,
           section.introductionContent,
+          section.introductionPageDescription,
           section.id,
           ctx
         )

--- a/src/eq_schema/schema/Section/index.test.js
+++ b/src/eq_schema/schema/Section/index.test.js
@@ -89,6 +89,7 @@ describe("Section", () => {
       sectionJSON.introductionTitle = title;
       sectionJSON.introductionContent = `<p>${description}</p>`;
       sectionJSON.introductionPageDescription = pageTitle;
+      sectionJSON.introductionEnabled = true;
 
       const section = new Section(sectionJSON, createCtx());
       const introBlock = section.groups[0].blocks[0];
@@ -103,6 +104,24 @@ describe("Section", () => {
       const sectionJSON = createSectionJSON();
       const section = new Section(sectionJSON, createCtx());
       expect(section.groups[0].blocks[0].type).not.toBe("Interstitial");
+    });
+
+    it("shouldn't add introduction block when section introduction page is not enabled", () => {
+      const sectionJSON = createSectionJSON();
+      const title = "Beware the Jabberwock!";
+      const description = "The jaws that bite! The claws that snatch!";
+      const pageTitle = "Jabberwocky";
+      sectionJSON.introductionTitle = title;
+      sectionJSON.introductionContent = `<p>${description}</p>`;
+      sectionJSON.introductionPageDescription = pageTitle;
+      sectionJSON.introductionEnabled = false;
+
+      const section = new Section(sectionJSON, createCtx());
+      const firstBlock = section.groups[0].blocks[0];
+
+      expect(firstBlock.type).not.toBe("Interstitial");
+      expect(firstBlock.page_title).not.toBe(pageTitle);
+      expect(firstBlock.content).toBeUndefined();
     });
   });
 

--- a/src/eq_schema/schema/Section/index.test.js
+++ b/src/eq_schema/schema/Section/index.test.js
@@ -18,7 +18,7 @@ describe("Section", () => {
             ],
           },
         ],
-        pageDescription: "Section 1 Page Title"
+        sectionSummaryPageDescription: "Section 1 Page Title",
       },
       options
     );
@@ -85,8 +85,10 @@ describe("Section", () => {
       const sectionJSON = createSectionJSON();
       const title = "Beware the Jabberwock!";
       const description = "The jaws that bite! The claws that snatch!";
+      const pageTitle = "Jabberwocky";
       sectionJSON.introductionTitle = title;
       sectionJSON.introductionContent = `<p>${description}</p>`;
+      sectionJSON.introductionPageDescription = pageTitle;
 
       const section = new Section(sectionJSON, createCtx());
       const introBlock = section.groups[0].blocks[0];
@@ -94,6 +96,7 @@ describe("Section", () => {
       expect(introBlock.type).toBe("Interstitial");
       expect(introBlock.content.title).toBe(title);
       expect(introBlock.content.contents[0].description).toBe(description);
+      expect(introBlock.page_title).toBe(pageTitle);
     });
 
     it("shouldn't add introduction block when there's no title / content", () => {
@@ -160,7 +163,7 @@ describe("Section", () => {
     const listCollectorSection = {
       id: "1",
       title: "Section 1",
-      pageDescription: "Section 1 Page Title",
+      sectionSummaryPageDescription: "Section 1 Page Title",
       folders: [
         {
           id: "folder-1",
@@ -207,7 +210,7 @@ describe("Section", () => {
             {
               id: "3",
               answers: [],
-              listName: "test3"
+              listName: "test3",
             },
           ],
         },
@@ -223,6 +226,7 @@ describe("Section", () => {
         id: "section1",
         summary: {
           show_on_completion: true,
+          page_title: "Section 1 Page Title",
           items: [
             {
               type: "List",


### PR DESCRIPTION
### What is the context of this PR?

**Tickets:** https://jira.ons.gov.uk/browse/EAR-2033 and https://jira.ons.gov.uk/browse/EAR-2035
**Author PR:** https://github.com/ONSdigital/eq-author-app/pull/2959

_This PR is for both EAR 2033 and EAR 2035_
Add Publisher changes for section page redesign, including section introduction page description and section summary page description

### How to review
**Check:**
- [ ] Section introduction page description is displayed in eQ's section introduction tab
- [ ] Section summary page description is displayed in eQ's section summary tab
- [ ] Other page descriptions are displayed in their eQ tabs
- [ ] Section introduction page is not displayed in eQ when section introduction page is not enabled in Author

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process
