### PR TITLE
EAR-2025-delete-null-legal-basis-field

### DIFF
--- a/src/eq_schema/schema/Questionnaire/index.js
+++ b/src/eq_schema/schema/Questionnaire/index.js
@@ -26,6 +26,10 @@ class Questionnaire {
     this.form_type = formType || "9999";
     this.legal_basis = contentMap[legalBasis];
 
+    if (this.legal_basis === null) {
+      delete this.legal_basis;
+    }
+
     if (questionnaireJson.dataVersion === "3") {
       this.answer_codes = createAnswerCodes(questionnaireJson);
     }

--- a/src/eq_schema/schema/Questionnaire/index.js
+++ b/src/eq_schema/schema/Questionnaire/index.js
@@ -24,10 +24,9 @@ class Questionnaire {
 
     this.survey_id = surveyId || "zzz";
     this.form_type = formType || "9999";
-    this.legal_basis = contentMap[legalBasis];
 
-    if (this.legal_basis === null) {
-      delete this.legal_basis;
+    if (contentMap[legalBasis]) {
+      this.legal_basis = contentMap[legalBasis];
     }
 
     if (questionnaireJson.dataVersion === "3") {

--- a/src/eq_schema/schema/Questionnaire/index.test.js
+++ b/src/eq_schema/schema/Questionnaire/index.test.js
@@ -102,6 +102,14 @@ describe("Questionnaire", () => {
     });
   });
 
+  it("should delete legal_basis key is the value is null", () => {
+    const questionnaire = new Questionnaire(
+      createQuestionnaireJSON({ legalBasis: "VOLUNTARY" })
+    );
+
+    expect(questionnaire.legal_basis).toBeUndefined();
+  });
+
   it("should build navigation", () => {
     const questionnaire = new Questionnaire(
       createQuestionnaireJSON({

--- a/src/eq_schema/schema/Questionnaire/index.test.js
+++ b/src/eq_schema/schema/Questionnaire/index.test.js
@@ -102,7 +102,7 @@ describe("Questionnaire", () => {
     });
   });
 
-  it("should delete legal_basis key is the value is null", () => {
+  it("should delete the legal_basis key if the value is null", () => {
     const questionnaire = new Questionnaire(
       createQuestionnaireJSON({ legalBasis: "VOLUNTARY" })
     );


### PR DESCRIPTION
Checkout `EAR-2025-delete-null-legal-basis-field`

- [x] Create a questionnaire with a voluntary legal basis
- [x] Check the runner schema, the legal_basis field should be deleted
- [x] Check that other legal basis options are unaffected