### PR TITLE
EAR-2185-Fix-publisher-section-summary-for-non-lists

### DIFF
--- a/src/eq_schema/schema/Section/index.js
+++ b/src/eq_schema/schema/Section/index.js
@@ -66,7 +66,7 @@ class Section {
     this.summary = {
       show_on_completion: section.sectionSummary || false,
       page_title: processPipe(ctx)(section.sectionSummaryPageDescription),
-      show_non_item_answers: true,
+
       collapsible: false,
     };
 


### PR DESCRIPTION
This PR is linked to this [Jira ticket](https://jira.ons.gov.uk/browse/EAR-2185)

How to review

- [ ] Import  [BICS wave 88](https://prod.author.eqbs.gcp.onsdigital.uk/#/q/e723ee5d-6e64-47c3-934a-e61d81528cf6/settings) to local author
- [ ] Open the runner schema, the field `show_non_item_answers` should not be in the schema
- [ ] Run runner schema through validator, it should pass (It may fail due to an extra dash in the section id, refer to [EAR 2184](https://jira.ons.gov.uk/browse/EAR-2184))