### PR TITLE
Tweaked formatPageDescription, and added appropriate tests

### DIFF
--- a/src/utils/functions/formatPageDescription.js
+++ b/src/utils/functions/formatPageDescription.js
@@ -1,8 +1,10 @@
 const formatPageDescription = (stringToFormat) => {
   // Remove special characters from string, replace spaces with hyphens, and convert to lower case
   const formattedString = stringToFormat
-    .replace(/[^\w\s]/gi, "")
+    .trim()
+    .replace(/[^\w\s-]/gi, "")
     .replace(/ /g, "-")
+    .split(/-+/).join('-')
     .toLowerCase();
 
   return formattedString;

--- a/src/utils/functions/formatPageDescription.test.js
+++ b/src/utils/functions/formatPageDescription.test.js
@@ -1,0 +1,24 @@
+const {formatPageDescription} = require("./formatPageDescription")
+
+describe("Formatting page description", () => {
+  it("should remove leading and trailing spaces and format", () => {
+    expect(formatPageDescription(" Leading and trailing spaces ")).toBe("leading-and-trailing-spaces");
+  });
+  it("should remove multiple in text spaces and format", () => {
+    expect(formatPageDescription("Extra     spaces")).toBe("extra-spaces");
+  });
+  it("should remove non-alpha-numeric characters and format", () => {
+    expect(formatPageDescription("Question mark?")).toBe("question-mark");
+    expect(formatPageDescription("!Exclamation")).toBe("exclamation");
+    expect(formatPageDescription("One & Two")).toBe("one-two");
+  });
+  it("should change multiple dashes to single and format", () => {
+    expect(formatPageDescription("Multiple-------Dashes")).toBe("multiple-dashes");
+  });
+  it("should change to all lowercase and format", () => {
+    expect(formatPageDescription("IN UPPERCASE")).toBe("in-uppercase");
+  });
+  it("should change not remove hyphens", () => {
+    expect(formatPageDescription("hyphenated-word")).toBe("hyphenated-word");
+  });
+});


### PR DESCRIPTION
### Motivation and Context
Changes to the formatPageDescription function to prevent trailing '-'

### What has changed
Added .trim() to function to initially remove any trailing/leading whitespace
Tweaked regex to allow '-' as well as alpha-numeric characters and spaces to prevent loss of hyphenated words
Added split/join to remove multiple '-' in outputs
Added tests to confirm the various formatting outputs render as expected

### How to test?

1. Add a section
2. Toggle section introduction page
3. Add a section page description with an extra space at the end
4. Confirm that the 'convert' block > id value has no trailing '-'
5. Confirm that questionnaire passes through validation
6. Test additionally for leading spaces, multiple spaces etc to confirm appropriate formatting

### Links
https://jira.ons.gov.uk/browse/EAR-2184