### PR TITLE
EAR 2192 additional content on LC page

### DIFF
--- a/src/eq_schema/block-types/listCollector/__snapshots__/index.test.js.snap
+++ b/src/eq_schema/block-types/listCollector/__snapshots__/index.test.js.snap
@@ -21,6 +21,119 @@ AddBlock {
 }
 `;
 
+exports[`Add Block should populate the definitons field when there is content and is enabled 1`] = `
+AddBlock {
+  "cancel_text": "Don’t need to add this item",
+  "id": "add-block-add-item-page-title",
+  "page_title": "Add item page title",
+  "question": Object {
+    "answers": Array [
+      Answer {
+        "id": "answeranswer-1",
+        "mandatory": false,
+        "type": undefined,
+      },
+    ],
+    "definitions": Array [
+      Object {
+        "contents": Array [
+          Object {
+            "title": "hello world",
+          },
+        ],
+        "title": "definition label",
+      },
+    ],
+    "id": "add-block-question-add-item-page-title",
+    "title": "Enter details",
+    "type": "General",
+  },
+  "type": "ListAddQuestion",
+}
+`;
+
+exports[`Add Block should populate the description field when there is content and is enabled 1`] = `
+AddBlock {
+  "cancel_text": "Don’t need to add this item",
+  "id": "add-block-add-item-page-title",
+  "page_title": "Add item page title",
+  "question": Object {
+    "answers": Array [
+      Answer {
+        "id": "answeranswer-1",
+        "mandatory": false,
+        "type": undefined,
+      },
+    ],
+    "description": Array [
+      "<h2>hello world</h2>",
+    ],
+    "id": "add-block-question-add-item-page-title",
+    "title": "Enter details",
+    "type": "General",
+  },
+  "type": "ListAddQuestion",
+}
+`;
+
+exports[`Add Block should populate the guidance field in the answers object when there is addtionalInfo content and is enabled 1`] = `
+AddBlock {
+  "cancel_text": "Don’t need to add this item",
+  "id": "add-block-add-item-page-title",
+  "page_title": "Add item page title",
+  "question": Object {
+    "answers": Array [
+      Answer {
+        "guidance": Object {
+          "contents": Array [
+            Object {
+              "description": "additionalInfo content",
+            },
+          ],
+          "hide_guidance": "additionalInfo label",
+          "show_guidance": "additionalInfo label",
+        },
+        "id": "answeranswer-1",
+        "mandatory": false,
+        "type": undefined,
+      },
+    ],
+    "id": "add-block-question-add-item-page-title",
+    "title": "Enter details",
+    "type": "General",
+  },
+  "type": "ListAddQuestion",
+}
+`;
+
+exports[`Add Block should populate the guidance field when there is content and is enabled 1`] = `
+AddBlock {
+  "cancel_text": "Don’t need to add this item",
+  "id": "add-block-add-item-page-title",
+  "page_title": "Add item page title",
+  "question": Object {
+    "answers": Array [
+      Answer {
+        "id": "answeranswer-1",
+        "mandatory": false,
+        "type": undefined,
+      },
+    ],
+    "guidance": Object {
+      "contents": Array [
+        Object {
+          "title": "hello world",
+        },
+      ],
+    },
+    "id": "add-block-question-add-item-page-title",
+    "title": "Enter details",
+    "type": "General",
+  },
+  "type": "ListAddQuestion",
+}
+`;
+
 exports[`Driving Block should build the driving block 1`] = `
 DrivingQuestion {
   "answers": Array [
@@ -73,6 +186,119 @@ EditBlock {
         "type": undefined,
       },
     ],
+    "id": "edit-block-question-add-item-page-title",
+    "title": "Enter details",
+    "type": "General",
+  },
+  "type": "ListEditQuestion",
+}
+`;
+
+exports[`Edit Block should populate the definitons field when there is content and is enabled 1`] = `
+EditBlock {
+  "cancel_text": "Don’t need to edit this item",
+  "id": "edit-block-add-item-page-title",
+  "page_title": "Add item page title",
+  "question": Object {
+    "answers": Array [
+      Answer {
+        "id": "answeranswer-1",
+        "mandatory": false,
+        "type": undefined,
+      },
+    ],
+    "definitions": Array [
+      Object {
+        "contents": Array [
+          Object {
+            "title": "hello world",
+          },
+        ],
+        "title": "definition label",
+      },
+    ],
+    "id": "edit-block-question-add-item-page-title",
+    "title": "Enter details",
+    "type": "General",
+  },
+  "type": "ListEditQuestion",
+}
+`;
+
+exports[`Edit Block should populate the description field when there is content and is enabled 1`] = `
+EditBlock {
+  "cancel_text": "Don’t need to edit this item",
+  "id": "edit-block-add-item-page-title",
+  "page_title": "Add item page title",
+  "question": Object {
+    "answers": Array [
+      Answer {
+        "id": "answeranswer-1",
+        "mandatory": false,
+        "type": undefined,
+      },
+    ],
+    "description": Array [
+      "<h2>hello world</h2>",
+    ],
+    "id": "edit-block-question-add-item-page-title",
+    "title": "Enter details",
+    "type": "General",
+  },
+  "type": "ListEditQuestion",
+}
+`;
+
+exports[`Edit Block should populate the guidance field in the answers object when there is addtionalInfo content and is enabled 1`] = `
+EditBlock {
+  "cancel_text": "Don’t need to edit this item",
+  "id": "edit-block-add-item-page-title",
+  "page_title": "Add item page title",
+  "question": Object {
+    "answers": Array [
+      Answer {
+        "guidance": Object {
+          "contents": Array [
+            Object {
+              "description": "additionalInfo content",
+            },
+          ],
+          "hide_guidance": "additionalInfo label",
+          "show_guidance": "additionalInfo label",
+        },
+        "id": "answeranswer-1",
+        "mandatory": false,
+        "type": undefined,
+      },
+    ],
+    "id": "edit-block-question-add-item-page-title",
+    "title": "Enter details",
+    "type": "General",
+  },
+  "type": "ListEditQuestion",
+}
+`;
+
+exports[`Edit Block should populate the guidance field when there is content and is enabled 1`] = `
+EditBlock {
+  "cancel_text": "Don’t need to edit this item",
+  "id": "edit-block-add-item-page-title",
+  "page_title": "Add item page title",
+  "question": Object {
+    "answers": Array [
+      Answer {
+        "id": "answeranswer-1",
+        "mandatory": false,
+        "type": undefined,
+      },
+    ],
+    "guidance": Object {
+      "contents": Array [
+        Object {
+          "title": "hello world",
+        },
+      ],
+    },
     "id": "edit-block-question-add-item-page-title",
     "title": "Enter details",
     "type": "General",

--- a/src/eq_schema/block-types/listCollector/addBlock.js
+++ b/src/eq_schema/block-types/listCollector/addBlock.js
@@ -7,23 +7,52 @@ const { getList } = require("../../../utils/functions/listGetters");
 const {
   formatPageDescription,
 } = require("../../../utils/functions/formatPageDescription");
+const {
+  wrapContents,
+  reversePipeContent,
+} = require("../../../utils/compoundFunctions");
 
 const processPipe = (ctx) => flow(convertPipes(ctx), getInnerHTMLWithPiping);
-
+const reversePipe = (ctx) =>
+  flow(wrapContents("contents"), reversePipeContent(ctx));
 class AddBlock {
   constructor(page, ctx) {
     this.id = `add-block-${formatPageDescription(page.pageDescription)}`;
     this.type = "ListAddQuestion";
     this.page_title = processPipe(ctx)(page.pageDescription);
 
-    this.cancel_text = "Don’t need to add this item";
+    this.cancel_text = "Don’t nCDeed to add this item";
+    this.question = this.buildQuestion(page, ctx);
+  }
+
+  buildQuestion(page, ctx) {
     const listAnswers = getList(ctx, page.listId).answers;
-    this.question = {
+    const question = {
       id: `add-block-question-${formatPageDescription(page.pageDescription)}`,
-      type: "General",
-      title: processPipe(ctx)(page.title),
-      answers: this.buildAnswers(listAnswers, ctx),
     };
+    if (page.descriptionEnabled && page.description) {
+      question.description = [convertPipes(ctx)(page.description)];
+    }
+
+    if (page.guidanceEnabled && page.guidance) {
+      question.guidance = reversePipe(ctx)(page.guidance);
+    }
+
+    if (
+      page.definitionEnabled &&
+      (page.definitionLabel || page.definitionContent)
+    ) {
+      question.definitions = [
+        {
+          title: processPipe(ctx)(page.definitionLabel),
+          ...reversePipe(ctx)(page.definitionContent),
+        },
+      ];
+    }
+    question.type = "General";
+    question.title = processPipe(ctx)(page.title);
+    question.answers = this.buildAnswers(listAnswers, ctx);
+    return question;
   }
 
   buildAnswers(answers, ctx) {

--- a/src/eq_schema/block-types/listCollector/addBlock.js
+++ b/src/eq_schema/block-types/listCollector/addBlock.js
@@ -1,6 +1,6 @@
 const convertPipes = require("../../../utils/convertPipes");
 const { getInnerHTMLWithPiping } = require("../../../utils/HTMLUtils");
-const { flow } = require("lodash/fp");
+const { flow, last } = require("lodash/fp");
 const { remove, cloneDeep } = require("lodash");
 const Answer = require("../../schema/Answer");
 const { getList } = require("../../../utils/functions/listGetters");
@@ -21,7 +21,7 @@ class AddBlock {
     this.type = "ListAddQuestion";
     this.page_title = processPipe(ctx)(page.pageDescription);
 
-    this.cancel_text = "Don’t nCDeed to add this item";
+    this.cancel_text = "Don’t need to add this item";
     this.question = this.buildQuestion(page, ctx);
   }
 
@@ -52,6 +52,16 @@ class AddBlock {
     question.type = "General";
     question.title = processPipe(ctx)(page.title);
     question.answers = this.buildAnswers(listAnswers, ctx);
+    if (
+      page.additionalInfoEnabled &&
+      (page.additionalInfoLabel || page.additionalInfoContent)
+    ) {
+      last(question.answers).guidance = {
+        show_guidance: processPipe(ctx)(page.additionalInfoLabel),
+        hide_guidance: processPipe(ctx)(page.additionalInfoLabel),
+        ...reversePipe(ctx)(page.additionalInfoContent),
+      };
+    }
     return question;
   }
 

--- a/src/eq_schema/block-types/listCollector/editBlock.js
+++ b/src/eq_schema/block-types/listCollector/editBlock.js
@@ -1,6 +1,6 @@
 const convertPipes = require("../../../utils/convertPipes");
 const { getInnerHTMLWithPiping } = require("../../../utils/HTMLUtils");
-const { flow } = require("lodash/fp");
+const { flow, last } = require("lodash/fp");
 const { remove, cloneDeep } = require("lodash");
 const Answer = require("../../schema/Answer");
 const { getList } = require("../../../utils/functions/listGetters");
@@ -52,6 +52,16 @@ class EditBlock {
     question.type = "General";
     question.title = processPipe(ctx)(page.title);
     question.answers = this.buildAnswers(listAnswers, ctx);
+    if (
+      page.additionalInfoEnabled &&
+      (page.additionalInfoLabel || page.additionalInfoContent)
+    ) {
+      last(question.answers).guidance = {
+        show_guidance: processPipe(ctx)(page.additionalInfoLabel),
+        hide_guidance: processPipe(ctx)(page.additionalInfoLabel),
+        ...reversePipe(ctx)(page.additionalInfoContent),
+      };
+    }
     return question;
   }
 

--- a/src/eq_schema/block-types/listCollector/editBlock.js
+++ b/src/eq_schema/block-types/listCollector/editBlock.js
@@ -7,7 +7,13 @@ const { getList } = require("../../../utils/functions/listGetters");
 const {
   formatPageDescription,
 } = require("../../../utils/functions/formatPageDescription");
+const {
+  wrapContents,
+  reversePipeContent,
+} = require("../../../utils/compoundFunctions");
 
+const reversePipe = (ctx) =>
+  flow(wrapContents("contents"), reversePipeContent(ctx));
 const processPipe = (ctx) => flow(convertPipes(ctx), getInnerHTMLWithPiping);
 
 class EditBlock {
@@ -16,13 +22,37 @@ class EditBlock {
     this.type = "ListEditQuestion";
     this.page_title = processPipe(ctx)(page.pageDescription);
     this.cancel_text = "Don’t need to edit this item";
+    this.question = this.buildQuestion(page, ctx);
+  }
+
+  buildQuestion(page, ctx) {
     const listAnswers = getList(ctx, page.listId).answers;
-    this.question = {
+    const question = {
       id: `edit-block-question-${formatPageDescription(page.pageDescription)}`,
-      type: "General",
-      title: processPipe(ctx)(page.title),
-      answers: this.buildAnswers(listAnswers, ctx),
     };
+    if (page.descriptionEnabled && page.description) {
+      question.description = [convertPipes(ctx)(page.description)];
+    }
+
+    if (page.guidanceEnabled && page.guidance) {
+      question.guidance = reversePipe(ctx)(page.guidance);
+    }
+
+    if (
+      page.definitionEnabled &&
+      (page.definitionLabel || page.definitionContent)
+    ) {
+      question.definitions = [
+        {
+          title: processPipe(ctx)(page.definitionLabel),
+          ...reversePipe(ctx)(page.definitionContent),
+        },
+      ];
+    }
+    question.type = "General";
+    question.title = processPipe(ctx)(page.title);
+    question.answers = this.buildAnswers(listAnswers, ctx);
+    return question;
   }
 
   buildAnswers(answers, ctx) {

--- a/src/eq_schema/block-types/listCollector/index.test.js
+++ b/src/eq_schema/block-types/listCollector/index.test.js
@@ -1,3 +1,5 @@
+const { last } = require("lodash/fp");
+
 const {
   ListCollectorQuestion,
   AddBlock,
@@ -41,6 +43,10 @@ const listCollectorFolder = {
     {
       id: "add-item-page",
       pageType: "ListCollectorAddItemPage",
+      descriptionEnabled: false,
+      guidanceEnabled: false,
+      definitionEnabled: false,
+      additionalInfoEnabled: false,
       title: "Enter details",
       pageDescription: "Add item page title",
       listId: "list1",
@@ -125,6 +131,104 @@ describe("Add Block", () => {
     );
     expect(confirmation).toMatchSnapshot();
   });
+
+  it("should be undefined when the additional content fields are disabled", () => {
+    const confirmation = new AddBlock(
+      listCollectorFolder.pages[1],
+      createCtx()
+    );
+
+    expect(confirmation.definitions).toBeUndefined();
+    expect(confirmation.guidance).toBeUndefined();
+    expect(confirmation.description).toBeUndefined();
+    expect(confirmation.additionalInfoContent).toBeUndefined();
+  });
+
+  it("should populate the description field when there is content and is enabled", () => {
+    const addBlockPage = {
+      id: "add-item-page",
+      pageType: "ListCollectorAddItemPage",
+      descriptionEnabled: true,
+      description: "<h2>hello world</h2>",
+      guidanceEnabled: false,
+      definitionEnabled: false,
+      additionalInfoEnabled: false,
+      title: "Enter details",
+      pageDescription: "Add item page title",
+      listId: "list1",
+      position: 1,
+    };
+    const confirmation = new AddBlock(addBlockPage, createCtx());
+
+    expect(confirmation.question.description).toBeDefined();
+    expect(confirmation).toMatchSnapshot();
+  });
+
+  it("should populate the guidance field when there is content and is enabled", () => {
+    const addBlockPage = {
+      id: "add-item-page",
+      pageType: "ListCollectorAddItemPage",
+      descriptionEnabled: false,
+      guidanceEnabled: true,
+      guidance: "<h2>hello world</h2>",
+      definitionEnabled: false,
+      additionalInfoEnabled: false,
+      title: "Enter details",
+      pageDescription: "Add item page title",
+      listId: "list1",
+      position: 1,
+    };
+    const confirmation = new AddBlock(addBlockPage, createCtx());
+    expect(confirmation.question.guidance).toBeDefined();
+    expect(confirmation).toMatchSnapshot();
+  });
+
+  it("should populate the definitons field when there is content and is enabled", () => {
+    const addBlockPage = {
+      id: "add-item-page",
+      pageType: "ListCollectorAddItemPage",
+      descriptionEnabled: false,
+      guidanceEnabled: false,
+      definitionEnabled: true,
+      definitionLabel: "definition label",
+      definitionContent: "<h2>hello world</h2>",
+      additionalInfoEnabled: false,
+      title: "Enter details",
+      pageDescription: "Add item page title",
+      listId: "list1",
+      position: 1,
+    };
+    const confirmation = new AddBlock(addBlockPage, createCtx());
+    expect(confirmation.question.definitions).toBeDefined();
+    expect(confirmation).toMatchSnapshot();
+  });
+
+  it("should populate the guidance field in the answers object when there is addtionalInfo content and is enabled", () => {
+    const addBlockPage = {
+      id: "add-item-page",
+      pageType: "ListCollectorAddItemPage",
+      descriptionEnabled: false,
+      guidanceEnabled: false,
+      definitionEnabled: false,
+      additionalInfoEnabled: true,
+      additionalInfoLabel: "additionalInfo label",
+      additionalInfoContent: "<p>additionalInfo content</p>",
+      title: "Enter details",
+      pageDescription: "Add item page title",
+      listId: "list1",
+      position: 1,
+    };
+    const confirmation = new AddBlock(addBlockPage, createCtx());
+    expect(last(confirmation.question.answers).guidance).toBeDefined();
+    expect(
+      last(confirmation.question.answers).guidance.show_guidance
+    ).toBeDefined();
+    expect(
+      last(confirmation.question.answers).guidance.hide_guidance
+    ).toBeDefined();
+    expect(last(confirmation.question.answers).guidance.contents).toBeDefined();
+    expect(confirmation).toMatchSnapshot();
+  });
 });
 
 describe("Edit Block", () => {
@@ -133,6 +237,92 @@ describe("Edit Block", () => {
       listCollectorFolder.pages[1],
       createCtx()
     );
+    expect(confirmation).toMatchSnapshot();
+  });
+
+  it("should populate the description field when there is content and is enabled", () => {
+    const editBlockPage = {
+      id: "add-item-page",
+      pageType: "ListCollectorAddItemPage",
+      descriptionEnabled: true,
+      description: "<h2>hello world</h2>",
+      guidanceEnabled: false,
+      definitionEnabled: false,
+      additionalInfoEnabled: false,
+      title: "Enter details",
+      pageDescription: "Add item page title",
+      listId: "list1",
+      position: 1,
+    };
+    const confirmation = new EditBlock(editBlockPage, createCtx());
+
+    expect(confirmation.question.description).toBeDefined();
+    expect(confirmation).toMatchSnapshot();
+  });
+
+  it("should populate the guidance field when there is content and is enabled", () => {
+    const editBlockPage = {
+      id: "add-item-page",
+      pageType: "ListCollectorAddItemPage",
+      descriptionEnabled: false,
+      guidanceEnabled: true,
+      guidance: "<h2>hello world</h2>",
+      definitionEnabled: false,
+      additionalInfoEnabled: false,
+      title: "Enter details",
+      pageDescription: "Add item page title",
+      listId: "list1",
+      position: 1,
+    };
+    const confirmation = new EditBlock(editBlockPage, createCtx());
+    expect(confirmation.question.guidance).toBeDefined();
+    expect(confirmation).toMatchSnapshot();
+  });
+
+  it("should populate the definitons field when there is content and is enabled", () => {
+    const editBlockPage = {
+      id: "add-item-page",
+      pageType: "ListCollectorAddItemPage",
+      descriptionEnabled: false,
+      guidanceEnabled: false,
+      definitionEnabled: true,
+      definitionLabel: "definition label",
+      definitionContent: "<h2>hello world</h2>",
+      additionalInfoEnabled: false,
+      title: "Enter details",
+      pageDescription: "Add item page title",
+      listId: "list1",
+      position: 1,
+    };
+    const confirmation = new EditBlock(editBlockPage, createCtx());
+    expect(confirmation.question.definitions).toBeDefined();
+    expect(confirmation).toMatchSnapshot();
+  });
+
+  it("should populate the guidance field in the answers object when there is addtionalInfo content and is enabled", () => {
+    const editBlockPage = {
+      id: "add-item-page",
+      pageType: "ListCollectorAddItemPage",
+      descriptionEnabled: false,
+      guidanceEnabled: false,
+      definitionEnabled: false,
+      additionalInfoEnabled: true,
+      additionalInfoLabel: "additionalInfo label",
+      additionalInfoContent: "<p>additionalInfo content</p>",
+      title: "Enter details",
+      pageDescription: "Add item page title",
+      listId: "list1",
+      position: 1,
+    };
+    const confirmation = new EditBlock(editBlockPage, createCtx());
+    expect(last(confirmation.question.answers).guidance).toBeDefined();
+    expect(
+      last(confirmation.question.answers).guidance.show_guidance
+    ).toBeDefined();
+    expect(
+      last(confirmation.question.answers).guidance.hide_guidance
+    ).toBeDefined();
+    expect(last(confirmation.question.answers).guidance.contents).toBeDefined();
     expect(confirmation).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Ticket: https://jira.ons.gov.uk/browse/EAR-2192

### What is the context of this PR?

> Add additional guidance to the collection question by adding the additional content collapsible on the add item page in the list collector folder

### How to review
1. Create a collection list
2. Add a list collector
3. Populate additional content fields in the add item page
4. Open the questionnaire in runner
- [ ] Check the additional content fields are displayed after selecting to add the list as well as editing the list after clicking 'change'