### PR TITLE
Filter out sds data set from metadata

### DIFF
--- a/src/eq_schema/schema/Questionnaire/index.js
+++ b/src/eq_schema/schema/Questionnaire/index.js
@@ -119,7 +119,9 @@ class Questionnaire {
   }
 
   buildMetadata(metadata) {
-    const userMetadata = metadata.map(({ key, type }) => ({
+    const userMetadata = metadata.filter(
+      ({ key }) => !["sds_dataset_id"].includes(key)
+    ).map(({ key, type }) => ({
       name: key,
       type: type === "Date" ? "date" : "string",
       optional: type === "Text_Optional" || undefined,


### PR DESCRIPTION
To test prepop we can add sds_dataset_id to the metadata page in Author, This will add it to the launch claims, but we don't want it coming out in the schema.
This PR removes sds_dataset_id from the schema metadata on conversion.

To test 

- Make a questionnaire
- add sds_dataset_id to the metadata page in Author
- convert a runner schema and check  sds_dataset_id  isn't in the list of metadata

 