### PR TITLE
EAR-2278 bug fix for piping variable calc sum 

### DIFF
--- a/src/middleware/remapIds/index.js
+++ b/src/middleware/remapIds/index.js
@@ -11,7 +11,7 @@ module.exports = (req, res, next) => {
   //function to remap page ids to page descriptions for variables piped in page titles
   const convertPiping = (html) => {
     const htmlData = cheerio.load(html)("body");
-    htmlData.find("[data-piped]").each((index, element) => {
+    htmlData.find("[data-piped]").each((_, element) => {
       const elementData = cheerio(element);
       if (
         elementData.data().piped === "variable" &&

--- a/src/middleware/remapIds/index.js
+++ b/src/middleware/remapIds/index.js
@@ -8,17 +8,20 @@ module.exports = (req, res, next) => {
   // Object storing IDs mapped to their page descriptions - used for referencing page descriptions
   const pageDescriptionLookupTable = {};
 
-  //function to remap page ids to page descriptions for variables piped in page titles 
+  //function to remap page ids to page descriptions for variables piped in page titles
   const convertPiping = (html) => {
-    const htmldata = cheerio.load(html)("body");
-    htmldata.find("[data-piped]").each((index, element) => {
+    const htmlData = cheerio.load(html)("body");
+    htmlData.find("[data-piped]").each((index, element) => {
       const elementData = cheerio(element);
-      if (elementData.data().piped === "variable" && elementData.data().id !== "total") {
+      if (
+        elementData.data().piped === "variable" &&
+        elementData.data().id !== "total"
+      ) {
         const newId = pageDescriptionLookupTable[elementData.data().id];
         elementData.attr("data-id", newId);
       }
     });
-    return htmldata.html();
+    return htmlData.html();
   };
 
   // Adds all IDs to lookup table with page descriptions, and remaps IDs to page descriptions
@@ -98,7 +101,7 @@ module.exports = (req, res, next) => {
     });
   });
 
-  //remaps the IDs in page titles if a variable is piped in 
+  //remaps the IDs in page titles if a variable is piped in
   res.locals.questionnaire.sections.forEach((section) => {
     section.folders.forEach((folder) => {
       folder.pages.forEach((page) => {

--- a/src/middleware/remapIds/index.test.js
+++ b/src/middleware/remapIds/index.test.js
@@ -220,6 +220,64 @@ describe("Remap Ids", () => {
                   drivingQCode: "q2",
                   anotherQCode: "q3",
                 },
+                {
+                  id: "page-5",
+                  title: "<p>calcsum</p>",
+                  pageType: "CalculatedSummaryPage",
+                  pageDescription: "Calculated Summary",
+                  type: "Number",
+                  totalTitle: "totalCalcSum",
+                  answers: [
+                    {
+                      id: "a18",
+                      type: "Number",
+                      label: "totalCalcSum",
+                      secondaryLabel: null,
+                      description: "",
+                      guidance: "",
+                      properties: {
+                        required: false,
+                      },
+                      qCode: "",
+                      secondaryQCode: null,
+                      validation: null,
+                    },
+                  ],
+                  summaryAnswers: [],
+                },
+
+                {
+                  id: "page-6",
+                  title:
+                    '<p>calc<span data-piped="variable" data-id="page-5">[totalCalcSum]</span></p>',
+                  pageType: "QuestionPage",
+                  pageDescription: "Question page 6",
+                  descriptionEnabled: false,
+                  guidance: null,
+                  guidanceEnabled: false,
+                  definitionLabel: null,
+                  definitionContent: null,
+                  definitionEnabled: false,
+                  additionalInfoLabel: null,
+                  additionalInfoContent: null,
+                  additionalInfoEnabled: false,
+                  answers: [
+                    {
+                      id: "a6",
+                      type: "TextField",
+                      label: "Label6",
+                      secondaryLabel: null,
+                      description: "",
+                      guidance: "",
+                      properties: {
+                        required: false,
+                      },
+                      qCode: "",
+                      secondaryQCode: null,
+                      validation: null,
+                    },
+                  ],
+                },
               ],
             },
           ],
@@ -308,6 +366,19 @@ describe("Remap Ids", () => {
     expect(res.locals.questionnaire).toEqual(questionnaire);
     expect(res.locals.questionnaire.sections[0].folders[0].pages[3].id).toEqual(
       "list1-repeat"
+    );
+  });
+
+  it("should remap the data id in the calculated summary variable piped into a page title ", () => {
+    req.body = questionnaire;
+
+    middleware = remapIds(req, res, next);
+
+    expect(res.locals.questionnaire).toEqual(questionnaire);
+    expect(
+      res.locals.questionnaire.sections[0].folders[0].pages[5].title
+    ).toEqual(
+      '<p>calc<span data-piped="variable" data-id="calculated-summary">[totalCalcSum]</span></p>'
     );
   });
 });

--- a/src/utils/convertPipes/PlaceholderObjectBuilder.js
+++ b/src/utils/convertPipes/PlaceholderObjectBuilder.js
@@ -13,7 +13,10 @@ const {
   // FORMAT_UNIT,
 } = require("../../constants/piping");
 const { removeDash } = require("../HTMLUtils");
-const { getValueSource, getSupplementaryValueSource } = require("../../eq_schema/builders/valueSource");
+const {
+  getValueSource,
+  getSupplementaryValueSource,
+} = require("../../eq_schema/builders/valueSource");
 
 const DATE_FORMAT_MAP = {
   "dd/mm/yyyy": "d MMMM yyyy",
@@ -62,13 +65,13 @@ const placeholderObjectBuilder = (
 
   if (source === "variable") {
     valueSource = {
-      source: "calculated_summary",
       identifier,
+      source: "calculated_summary",
     };
   }
 
   if (source === "supplementary") {
-    valueSource = getSupplementaryValueSource(ctx, identifier)
+    valueSource = getSupplementaryValueSource(ctx, identifier);
   }
 
   if (conditionalTradAs && placeholderName === "trad_as") {

--- a/src/utils/convertPipes/index.js
+++ b/src/utils/convertPipes/index.js
@@ -20,8 +20,11 @@ const getAnswers = (questionnaire) =>
   );
 
 const getSuplementaryField = (ctx, sourceId) => {
-  return find(flatMap(ctx.questionnaireJson.supplementaryData.data, "schemaFields"), { id: sourceId });
-}
+  return find(
+    flatMap(ctx.questionnaireJson.supplementaryData.data, "schemaFields"),
+    { id: sourceId }
+  );
+};
 
 const getListAnswers = (questionnaire) =>
   flatMap(get(questionnaire, "collectionLists.lists", []), (list) =>
@@ -125,11 +128,11 @@ const PIPE_TYPES = {
   },
   variable: {
     retrieve: ({ id }, ctx) => {
-      return getCalculatedSummary(ctx, id);
+      return getCalculatedSummary(ctx, id.toString());
     },
     getType: ({ type }) => type,
-    render: ({ id }) => `block${id}`,
-    placeholder: ({ id }) => `block${id}`,
+    render: ({ id }) => id,
+    placeholder: ({ totalTitle }) => formatter(totalTitle),
     getFallback: ({ fallbackKey }) =>
       fallbackKey
         ? { source: "calculated_summary", identifier: fallbackKey }
@@ -140,9 +143,11 @@ const PIPE_TYPES = {
     getType: ({ type }) => type,
     render: ({ id }) => id,
     placeholder: ({ identifier, selector }) =>
-      selector ? formatter(identifier) + "_" + formatter(selector) : formatter(identifier),
+      selector
+        ? formatter(identifier) + "_" + formatter(selector)
+        : formatter(identifier),
     getFallback: () => null,
-  }
+  },
 };
 
 const parseHTML = (html) => {

--- a/src/utils/convertPipes/index.test.js
+++ b/src/utils/convertPipes/index.test.js
@@ -112,6 +112,7 @@ const createContext = (metadata = []) => ({
                 id: "calc1",
                 pageType: "CalculatedSummaryPage",
                 type: "Number",
+                totalTitle:"blockcalc1"
               },
             ],
           },
@@ -385,7 +386,7 @@ describe("convertPipes", () => {
             "{blockcalc1}",
             createTransformation({
               placeholder: "blockcalc1",
-              identifier: "blockcalc1",
+              identifier: "calc1",
               source: "calculated_summary",
               argument: "number",
               transform: "format_number",


### PR DESCRIPTION
Ticket: https://jira.ons.gov.uk/browse/EAR-2278

Fix for when creating a questionnaire with number or currency questions with a calculated summary you cannot pipe the calculated summary value as a variable into a question.

### How to review
1. Create two number questions
2. Create a calculated summary of the two number answers
3. Create a follow on  question
4. Pipe the calculated summary into the follow on question title via answers piping and also via variable piping

- [ ] Check the convert for variable piping and answer piping are both displayed and are the same
- [ ] Check the correct values are displayed in the page title on the follow on question page in runner