### PR TITLE
EAR-1789 - Looping questions calculated summary

### DIFF
--- a/src/eq_schema/schema/Block/index.js
+++ b/src/eq_schema/schema/Block/index.js
@@ -1,5 +1,5 @@
-const { get, isNil, find, flatMap, some } = require("lodash");
-const { flow, getOr, last, map } = require("lodash/fp");
+const { get, isNil, find, flatMap } = require("lodash");
+const { flow, getOr, last, map, some } = require("lodash/fp");
 
 const convertPipes = require("../../../utils/convertPipes");
 const {
@@ -43,7 +43,7 @@ const getPages = (ctx) =>
 const getPageByAnswerId = (ctx, answerId) =>
   find(
     getPages(ctx),
-    (page) => page.answers && some(page.answers, { id: answerId })
+    (page) => page.answers && some({ id: answerId }, page.answers)
   );
 
 const getSections = (ctx) => ctx.questionnaireJson.sections;
@@ -51,7 +51,7 @@ const getSections = (ctx) => ctx.questionnaireJson.sections;
 const getFolders = (ctx) => flatMap(getSections(ctx), ({ folders }) => folders);
 
 const getFolderByPageId = (ctx, id) =>
-  find(getFolders(ctx), ({ pages }) => pages && some(pages, { id }));
+  find(getFolders(ctx), ({ pages }) => pages && some({ id }, pages));
 
 class Block {
   constructor(page, groupId, ctx) {

--- a/src/eq_schema/schema/Block/index.js
+++ b/src/eq_schema/schema/Block/index.js
@@ -132,7 +132,7 @@ class Block {
 
       let summaryAnswer, sourcePage, sourceFolder;
 
-      let onlyListCollectorAnswers = true;
+      let onlyListCollectorAnswers = false;
 
       for (let index = 0; index < page.summaryAnswers.length; index++) {
         summaryAnswer = page.summaryAnswers[index];
@@ -147,24 +147,24 @@ class Block {
               onlyListCollectorAnswers = false;
               break;
             }
-
-            if (onlyListCollectorAnswers) {
-              this.skip_conditions = {
-                when: {
-                  in: [
-                    {
-                      source: "answers",
-                      identifier: `answer-driving-${
-                        sourceFolder.pages[sourceFolder.pages.length - 1].id
-                      }`,
-                    },
-                    ["No"],
-                  ],
-                },
-              };
-            }
           }
         }
+      }
+
+      if (onlyListCollectorAnswers) {
+        this.skip_conditions = {
+          when: {
+            in: [
+              {
+                source: "answers",
+                identifier: `answer-driving-${
+                  sourceFolder.pages[sourceFolder.pages.length - 1].id
+                }`,
+              },
+              ["No"],
+            ],
+          },
+        };
       }
     }
   }

--- a/src/eq_schema/schema/Block/index.js
+++ b/src/eq_schema/schema/Block/index.js
@@ -149,10 +149,12 @@ class Block {
       if (onlyListCollectorAnswers) {
         this.skip_conditions = {
           when: {
-            "==": [
+            in: [
               {
                 source: "answers",
-                identifier: `answer${sourceFolder.pages[0].answers[0].id}`,
+                identifier: `answer-driving-${
+                  sourceFolder.pages[sourceFolder.pages.length - 1].id
+                }`,
               },
               ["No"],
             ],

--- a/src/eq_schema/schema/Block/index.js
+++ b/src/eq_schema/schema/Block/index.js
@@ -137,29 +137,34 @@ class Block {
       for (let index = 0; index < page.summaryAnswers.length; index++) {
         summaryAnswer = page.summaryAnswers[index];
         sourcePage = getPageByAnswerId(ctx, summaryAnswer);
-        sourceFolder = getFolderByPageId(ctx, sourcePage.id);
-        if (sourceFolder.listId) {
-          onlyListCollectorAnswers = true;
-        } else {
-          onlyListCollectorAnswers = false;
-          break;
-        }
-      }
+        if (sourcePage) {
+          sourceFolder = getFolderByPageId(ctx, sourcePage.id);
 
-      if (onlyListCollectorAnswers) {
-        this.skip_conditions = {
-          when: {
-            in: [
-              {
-                source: "answers",
-                identifier: `answer-driving-${
-                  sourceFolder.pages[sourceFolder.pages.length - 1].id
-                }`,
-              },
-              ["No"],
-            ],
-          },
-        };
+          if (sourceFolder) {
+            if (sourceFolder.listId) {
+              onlyListCollectorAnswers = true;
+            } else {
+              onlyListCollectorAnswers = false;
+              break;
+            }
+
+            if (onlyListCollectorAnswers) {
+              this.skip_conditions = {
+                when: {
+                  in: [
+                    {
+                      source: "answers",
+                      identifier: `answer-driving-${
+                        sourceFolder.pages[sourceFolder.pages.length - 1].id
+                      }`,
+                    },
+                    ["No"],
+                  ],
+                },
+              };
+            }
+          }
+        }
       }
     }
   }

--- a/src/eq_schema/schema/Block/index.js
+++ b/src/eq_schema/schema/Block/index.js
@@ -105,6 +105,8 @@ class Block {
   }
 
   buildPages(page, ctx) {
+    let sourceFolder;
+
     if (
       page.pageType === "QuestionPage" ||
       page.pageType === "ConfirmationQuestion"
@@ -130,26 +132,15 @@ class Block {
         title: processPipe(ctx)(page.totalTitle),
       };
 
-      let summaryAnswer, sourcePage, sourceFolder;
+      const onlyListCollectorAnswers = page.summaryAnswers.every(
+        (summaryAnswerId) => {
+          const sourcePage = getPageByAnswerId(ctx, summaryAnswerId);
 
-      let onlyListCollectorAnswers = false;
+          sourceFolder = sourcePage && getFolderByPageId(ctx, sourcePage.id);
 
-      for (let index = 0; index < page.summaryAnswers.length; index++) {
-        summaryAnswer = page.summaryAnswers[index];
-        sourcePage = getPageByAnswerId(ctx, summaryAnswer);
-        if (sourcePage) {
-          sourceFolder = getFolderByPageId(ctx, sourcePage.id);
-
-          if (sourceFolder) {
-            if (sourceFolder.listId) {
-              onlyListCollectorAnswers = true;
-            } else {
-              onlyListCollectorAnswers = false;
-              break;
-            }
-          }
+          return sourceFolder && sourceFolder.listId !== undefined;
         }
-      }
+      );
 
       if (onlyListCollectorAnswers) {
         this.skip_conditions = {

--- a/src/eq_schema/schema/Block/index.test.js
+++ b/src/eq_schema/schema/Block/index.test.js
@@ -1,5 +1,4 @@
 const Block = require(".");
-const { isLastPageInSection } = require(".");
 const Question = require("../Question");
 const ctx = {
   questionnaireJson: {

--- a/src/eq_schema/schema/Block/index.test.js
+++ b/src/eq_schema/schema/Block/index.test.js
@@ -180,5 +180,271 @@ describe("Block", () => {
         type: "CalculatedSummary",
       });
     });
+
+    it("should build a calculated summary page with skip condition when there is only one list collector follow up answer", () => {
+      const calculatedPageGraphql = {
+        totalTitle: "<p>Summary title1</p>",
+        answers: [
+          {
+            label: "<p>Summary title1</p>",
+            type: "Number",
+            id: "9d2b3354-9751-4be4-9523-1f36345c3069",
+            validation: {},
+            properties: {},
+          },
+        ],
+        title: "<p>Summary1</p>",
+        type: "Number",
+        pageType: "CalculatedSummaryPage",
+        summaryAnswers: ["36e1779d-267f-4f69-85e3-a7335371bfb8"],
+        pageDescription: "Summary page1",
+        alias: null,
+        id: "summary-page1",
+        listId: undefined,
+      };
+
+      ctx.questionnaireJson = {
+        metadata: [{ id: "123", type: "Text", key: "my_metadata" }],
+        sections: [
+          {
+            folders: [
+              {
+                id: "folder-1",
+                pages: [
+                  { answers: [{ id: `1`, label: "Answer 1", type: "Text" }] },
+                ],
+              },
+              {
+                displayName: "",
+                title: "List1",
+                folderId: "792a1b8d-0492-4f5d-ae94-33c9ff8d8a0b",
+                listId: "cd9faacd-6d32-4fb1-86ae-7cbf13d633f9",
+                pages: [
+                  {
+                    answers: [
+                      {
+                        qCode: "q2",
+                        label: "",
+                        type: "Radio",
+                        options: [
+                          {
+                            qCode: "",
+                            label: "Yes",
+                            id: "1b947f24-7612-422e-802f-ee3560694266",
+                          },
+                          {
+                            qCode: "",
+                            label: "No",
+                            id: "0fb66dce-b27c-4db0-af9c-236a1a4a5ed0",
+                          },
+                        ],
+                        id: "4622b458-02b7-457d-90bb-34e2e4fc5861",
+                        properties: {
+                          required: false,
+                        },
+                        validation: {},
+                      },
+                    ],
+                    title: "<p>Qualifier1</p>",
+                    additionalGuidanceEnabled: false,
+                    additionalGuidanceContent: "",
+                    pageType: "ListCollectorQualifierPage",
+                    pageDescription: "Qualifier page1",
+                    alias: null,
+                    id: "f5020d43-1ecb-43f7-91f1-408d7aaf5982",
+                    position: 0,
+                  },
+                  {
+                    definitionEnabled: false,
+                    additionalInfoContent: null,
+                    description: null,
+                    title: "<p>Add1</p>",
+                    definitionLabel: null,
+                    additionalInfoLabel: null,
+                    pageType: "ListCollectorAddItemPage",
+                    descriptionEnabled: false,
+                    additionalInfoEnabled: false,
+                    definitionContent: null,
+                    guidance: null,
+                    pageDescription: "Add page1",
+                    alias: null,
+                    guidanceEnabled: false,
+                    id: "a42609e3-83eb-4469-8416-469218d3e779",
+                    position: 1,
+                  },
+                  {
+                    definitionEnabled: false,
+                    additionalInfoContent: null,
+                    answers: [
+                      {
+                        qCode: "",
+                        description: "",
+                        label: "<p>Follow1</p>",
+                        type: "Number",
+                        repeatingLabelAndInputListId: "",
+                        repeatingLabelAndInput: false,
+                        guidance: "",
+                        id: "36e1779d-267f-4f69-85e3-a7335371bfb8",
+                        questionPageId: "cf8b1c62-e827-4b48-b051-161ae363071c",
+                        properties: {
+                          required: false,
+                          decimals: 0,
+                        },
+                        validation: {
+                          maxValue: {
+                            inclusive: true,
+                            entityType: "Custom",
+                            validationType: "maxValue",
+                            enabled: false,
+                            id: "4262f139-c8f7-4567-a20d-f65cc6d4acfb",
+                          },
+                          minValue: {
+                            inclusive: true,
+                            entityType: "Custom",
+                            validationType: "minValue",
+                            enabled: false,
+                            id: "a97f2945-ebee-46d5-a263-c8683c483876",
+                          },
+                        },
+                      },
+                    ],
+                    description: "",
+                    title: "<p>Follow1</p>",
+                    definitionLabel: null,
+                    routing: null,
+                    additionalInfoLabel: null,
+                    pageType: "QuestionPage",
+                    descriptionEnabled: false,
+                    additionalInfoEnabled: false,
+                    definitionContent: null,
+                    guidance: null,
+                    pageDescription: "Follow page1",
+                    alias: null,
+                    guidanceEnabled: false,
+                    id: "cf8b1c62-e827-4b48-b051-161ae363071c",
+                  },
+                  {
+                    definitionEnabled: false,
+                    additionalInfoContent: null,
+                    answers: [
+                      {
+                        qCode: "",
+                        description: "",
+                        label: "<p>Copy of Follow1</p>",
+                        type: "Number",
+                        repeatingLabelAndInputListId: "",
+                        repeatingLabelAndInput: false,
+                        guidance: "",
+                        id: "4ce9825e-b48f-4e79-8007-2555a2496fd7",
+                        questionPageId: "cf8b1c62-e827-4b48-b051-161ae363071c",
+                        properties: {
+                          required: false,
+                          decimals: 0,
+                        },
+                        validation: {
+                          maxValue: {
+                            inclusive: true,
+                            entityType: "Custom",
+                            validationType: "maxValue",
+                            enabled: false,
+                            id: "095e5390-9727-4389-ac3b-87560258fa78",
+                          },
+                          minValue: {
+                            inclusive: true,
+                            entityType: "Custom",
+                            validationType: "minValue",
+                            enabled: false,
+                            id: "655b1551-33fd-4666-8195-32740530e23a",
+                          },
+                        },
+                      },
+                    ],
+                    description: "",
+                    title: "<p>Copy of Follow1</p>",
+                    definitionLabel: null,
+                    routing: null,
+                    additionalInfoLabel: null,
+                    pageType: "QuestionPage",
+                    descriptionEnabled: false,
+                    additionalInfoEnabled: false,
+                    definitionContent: null,
+                    guidance: null,
+                    pageDescription: "Copy of Follow page1",
+                    alias: "",
+                    guidanceEnabled: false,
+                    id: "ce9cfefe-2761-4a0b-b7c9-93b59b27f8e8",
+                  },
+                  {
+                    answers: [
+                      {
+                        qCode: "q3",
+                        label: "",
+                        type: "Radio",
+                        options: [
+                          {
+                            qCode: "",
+                            label: "Yes",
+                            id: "aa04e6a2-0449-40ce-a84e-301444a705df",
+                          },
+                          {
+                            qCode: "",
+                            label: "No",
+                            id: "eb4bb680-66c5-49e3-a440-d1028cceac59",
+                          },
+                        ],
+                        id: "a701b7d3-a0f3-4f31-99e3-69e5b8c0311f",
+                        properties: {
+                          required: false,
+                        },
+                        validation: {},
+                      },
+                    ],
+                    title: "<p>Confirm1</p>",
+                    pageType: "ListCollectorConfirmationPage",
+                    pageDescription: "Confirm page1",
+                    alias: null,
+                    id: "cda52f43-b655-4e89-b7c5-75f038a7369d",
+                    position: 2,
+                  },
+                ],
+                alias: "",
+                id: "792a1b8d-0492-4f5d-ae94-33c9ff8d8a0b",
+              },
+            ],
+          },
+        ],
+      };
+      const block = new Block(calculatedPageGraphql, null, ctx);
+
+      expect(block).toMatchObject({
+        id: "summary-page1",
+        type: "CalculatedSummary",
+        page_title: "Summary page1",
+        title: "Summary1",
+        calculation: {
+          operation: {
+            "+": [
+              {
+                identifier: "answer36e1779d-267f-4f69-85e3-a7335371bfb8",
+                source: "answers",
+              },
+            ],
+          },
+          title: "Summary title1",
+        },
+        skip_conditions: {
+          when: {
+            in: [
+              {
+                source: "answers",
+                identifier:
+                  "answer-driving-cda52f43-b655-4e89-b7c5-75f038a7369d",
+              },
+              ["No"],
+            ],
+          },
+        },
+      });
+    });
   });
 });

--- a/src/eq_schema/schema/Block/index.test.js
+++ b/src/eq_schema/schema/Block/index.test.js
@@ -82,29 +82,6 @@ describe("Block", () => {
     });
   });
 
-  describe("isNotLastPageInSection", () => {
-    const questionnaire = {
-      sections: [
-        {
-          pages: [{ id: "1" }, { id: "2" }],
-        },
-        {
-          pages: [{ id: "3" }, { id: "4" }],
-        },
-      ],
-    };
-
-    it("should return true if is a last page", () => {
-      expect(isLastPageInSection({ id: "2" }, questionnaire)).toBe(true);
-      expect(isLastPageInSection({ id: "4" }, questionnaire)).toBe(true);
-    });
-
-    it("should return false if not a last page in a section", () => {
-      expect(isLastPageInSection({ id: "1" }, questionnaire)).toBe(false);
-      expect(isLastPageInSection({ id: "3" }, questionnaire)).toBe(false);
-    });
-  });
-
   describe("piping", () => {
     const createPipeInText = ({
       id = 1,

--- a/src/eq_schema/schema/Block/index.test.js
+++ b/src/eq_schema/schema/Block/index.test.js
@@ -1,4 +1,5 @@
 const Block = require(".");
+const { isLastPageInSection } = require(".");
 const Question = require("../Question");
 const ctx = {
   questionnaireJson: {
@@ -78,6 +79,29 @@ describe("Block", () => {
       );
 
       expect(block.type).toEqual("Interstitial");
+    });
+  });
+
+  describe("isNotLastPageInSection", () => {
+    const questionnaire = {
+      sections: [
+        {
+          pages: [{ id: "1" }, { id: "2" }],
+        },
+        {
+          pages: [{ id: "3" }, { id: "4" }],
+        },
+      ],
+    };
+
+    it("should return true if is a last page", () => {
+      expect(isLastPageInSection({ id: "2" }, questionnaire)).toBe(true);
+      expect(isLastPageInSection({ id: "4" }, questionnaire)).toBe(true);
+    });
+
+    it("should return false if not a last page in a section", () => {
+      expect(isLastPageInSection({ id: "1" }, questionnaire)).toBe(false);
+      expect(isLastPageInSection({ id: "3" }, questionnaire)).toBe(false);
     });
   });
 

--- a/src/eq_schema/schema/Block/index.test.js
+++ b/src/eq_schema/schema/Block/index.test.js
@@ -205,28 +205,7 @@ describe("Block", () => {
       });
     });
 
-    it("should build a calculated summary page with skip condition when there is only one list collector follow up answer", () => {
-      const calculatedPageGraphql = {
-        totalTitle: "<p>Summary title1</p>",
-        answers: [
-          {
-            label: "<p>Summary title1</p>",
-            type: "Number",
-            id: "9d2b3354-9751-4be4-9523-1f36345c3069",
-            validation: {},
-            properties: {},
-          },
-        ],
-        title: "<p>Summary1</p>",
-        type: "Number",
-        pageType: "CalculatedSummaryPage",
-        summaryAnswers: ["36e1779d-267f-4f69-85e3-a7335371bfb8"],
-        pageDescription: "Summary page1",
-        alias: null,
-        id: "summary-page1",
-        listId: undefined,
-      };
-
+    describe("calculated summary page with and without skip condition", () => {
       ctx.questionnaireJson = {
         metadata: [{ id: "123", type: "Text", key: "my_metadata" }],
         sections: [
@@ -235,7 +214,12 @@ describe("Block", () => {
               {
                 id: "folder-1",
                 pages: [
-                  { answers: [{ id: `1`, label: "Answer 1", type: "Text" }] },
+                  {
+                    answers: [
+                      { id: "num-1", label: "Answer 1", type: "Number" },
+                    ],
+                    id: "page-1",
+                  },
                 ],
               },
               {
@@ -308,7 +292,7 @@ describe("Block", () => {
                         repeatingLabelAndInputListId: "",
                         repeatingLabelAndInput: false,
                         guidance: "",
-                        id: "36e1779d-267f-4f69-85e3-a7335371bfb8",
+                        id: "list-follow-1",
                         questionPageId: "cf8b1c62-e827-4b48-b051-161ae363071c",
                         properties: {
                           required: false,
@@ -438,36 +422,102 @@ describe("Block", () => {
           },
         ],
       };
-      const block = new Block(calculatedPageGraphql, null, ctx);
+      it("should build a calculated summary page with skip condition when it contains only one list collector follow up answer", () => {
+        const calculatedPageGraphql = {
+          totalTitle: "<p>Summary title1</p>",
+          answers: [
+            {
+              label: "<p>Summary title1</p>",
+              type: "Number",
+              id: "9d2b3354-9751-4be4-9523-1f36345c3069",
+              validation: {},
+              properties: {},
+            },
+          ],
+          title: "<p>Summary1</p>",
+          type: "Number",
+          pageType: "CalculatedSummaryPage",
+          summaryAnswers: ["list-follow-1"],
+          pageDescription: "Summary page1",
+          alias: null,
+          id: "summary-page1",
+          listId: undefined,
+        };
 
-      expect(block).toMatchObject({
-        id: "summary-page1",
-        type: "CalculatedSummary",
-        page_title: "Summary page1",
-        title: "Summary1",
-        calculation: {
-          operation: {
-            "+": [
-              {
-                identifier: "answer36e1779d-267f-4f69-85e3-a7335371bfb8",
-                source: "answers",
-              },
-            ],
+        const block = new Block(calculatedPageGraphql, null, ctx);
+
+        expect(block).toMatchObject({
+          id: "summary-page1",
+          type: "CalculatedSummary",
+          page_title: "Summary page1",
+          title: "Summary1",
+          calculation: {
+            operation: {
+              "+": [
+                {
+                  identifier: "answerlist-follow-1",
+                  source: "answers",
+                },
+              ],
+            },
+            title: "Summary title1",
           },
-          title: "Summary title1",
-        },
-        skip_conditions: {
-          when: {
-            in: [
-              {
-                source: "answers",
-                identifier:
-                  "answer-driving-cda52f43-b655-4e89-b7c5-75f038a7369d",
-              },
-              ["No"],
-            ],
+          skip_conditions: {
+            when: {
+              in: [
+                {
+                  source: "answers",
+                  identifier:
+                    "answer-driving-cda52f43-b655-4e89-b7c5-75f038a7369d",
+                },
+                ["No"],
+              ],
+            },
           },
-        },
+        });
+      });
+
+      it("should build a calculated summary page without skip condition when it contains a normal answer", () => {
+        const calculatedPageGraphql = {
+          totalTitle: "<p>Summary title1</p>",
+          answers: [
+            {
+              label: "<p>Summary title1</p>",
+              type: "Number",
+              id: "9d2b3354-9751-4be4-9523-1f36345c3069",
+              validation: {},
+              properties: {},
+            },
+          ],
+          title: "<p>Summary1</p>",
+          type: "Number",
+          pageType: "CalculatedSummaryPage",
+          summaryAnswers: ["num-1"],
+          pageDescription: "Summary page1",
+          alias: null,
+          id: "summary-page1",
+          listId: undefined,
+        };
+
+        const block = new Block(calculatedPageGraphql, null, ctx);
+
+        expect(block).toMatchObject({
+          id: "summary-page1",
+          type: "CalculatedSummary",
+          page_title: "Summary page1",
+          title: "Summary1",
+          calculation: {
+            operation: {
+              "+": [
+                {
+                  identifier: "answernum-1",
+                  source: "answers",
+                },
+              ],
+            },
+            title: "Summary title1",
+          },
+        });
       });
     });
   });


### PR DESCRIPTION
https://jira.ons.gov.uk/browse/EAR-1789

- [ ] Select only one list collector follow-up answer in the calculated summary page
- [ ] The convert schema must contain the block with the 'skip_conditions' for the calculated summary page in a similar structure as given below
- [ ] If the calculated summary page contains at least one normal number answer with or without the list collector follow-up answer, then the below 'skip_conditions' block must not be present in the convert schema

"skip_conditions": {
"when": {
"in": [
     {
        "source": "answers",
        "identifier": "answer-driving-confirm-page1"
     },
     [
        "No"
     ]
   ]
  }
}