### PR TITLE
Add list collector answer codes

### DIFF
--- a/src/utils/createAnswerCodes/index.js
+++ b/src/utils/createAnswerCodes/index.js
@@ -12,7 +12,11 @@ const getAllAnswers = (questionnaireJson) => {
   questionnaireJson.sections.forEach((section) => {
     section.folders.forEach((folder) => {
       folder.pages.forEach((page) => {
-        if (page.pageType === "QuestionPage") {
+        if (
+          page.pageType === "QuestionPage" ||
+          page.pageType === "ListCollectorQualifierPage" ||
+          page.pageType === "ListCollectorConfirmationPage"
+        ) {
           page.answers.forEach((answer) => {
             allQuestionnaireAnswers.push(answer);
           });
@@ -30,27 +34,10 @@ const getAllAnswers = (questionnaireJson) => {
   return allQuestionnaireAnswers;
 };
 
-// Get all list collector pages in the questionnaire
-const getAllListCollectorPages = (questionnaireJson) => {
-  const allQuestionnaireListPages = [];
-  questionnaireJson.sections.forEach((section) => {
-    section.folders.forEach((folder) => {
-      folder.pages.forEach((page) => {
-        if (page.pageType === "ListCollectorPage") {
-          allQuestionnaireListPages.push(page);
-        }
-      });
-    });
-  });
-
-  return allQuestionnaireListPages;
-};
-
 // Generates answer codes for all answers
 const createAnswerCodes = (questionnaireJson) => {
   const answerCodes = [];
   const answers = getAllAnswers(questionnaireJson);
-  const listCollectorPages = getAllListCollectorPages(questionnaireJson);
 
   // Loop through all answers in the questionnaire
   answers.forEach((answer) => {
@@ -85,20 +72,6 @@ const createAnswerCodes = (questionnaireJson) => {
         });
       }
     }
-  });
-
-  // Add answer codes for list collector driving and repeating questions
-  listCollectorPages.forEach((page) => {
-    answerCodes.push(
-      {
-        answer_id: `answer-driving-${page.id}`,
-        code: page.drivingQCode,
-      },
-      {
-        answer_id: `add-another-${page.id}`,
-        code: page.anotherQCode,
-      }
-    );
   });
 
   return answerCodes;

--- a/src/utils/createAnswerCodes/index.test.js
+++ b/src/utils/createAnswerCodes/index.test.js
@@ -17,7 +17,11 @@ const {
 } = require("../../constants/answerTypes");
 
 describe("Create answer codes", () => {
-  const createQuestionnaireJSON = (answer, pageType = "QuestionPage") =>
+  const createQuestionnaireJSON = (
+    answer,
+    pageType = "QuestionPage",
+    withListCollector
+  ) =>
     Object.assign({
       id: "questionnaire-1",
       title: "Test questionnaire",
@@ -31,41 +35,88 @@ describe("Create answer codes", () => {
           folders: [
             {
               id: "folder-1",
-              pages: [
-                {
-                  id: "page-1",
-                  title: "Question 1",
-                  pageType,
-                  drivingQCode:
-                    pageType === "ListCollectorPage" && "driving-code",
-                  anotherQCode:
-                    pageType === "ListCollectorPage" && "another-code",
-                  answers: [
+              pages: withListCollector
+                ? [
                     {
-                      ...answer,
+                      id: "list-qualifier-page",
+                      title: "List qualifier title",
+                      pageType: "ListCollectorQualifierPage",
+                      answers: [
+                        {
+                          id: "qualifier-answer",
+                          type: "Radio",
+                          qCode: "qualifier-code",
+                          options: [
+                            {
+                              id: "qualifier-option-positive",
+                              label: "Yes",
+                            },
+                            {
+                              id: "qualifier-option-negative",
+                              label: "No",
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      id: "list-add-item-page",
+                      title: "List add item title",
+                      pageType: "ListCollectorAddItemPage",
+                    },
+                    {
+                      id: "list-confirmation-page",
+                      title: "List confirmation title",
+                      pageType: "ListCollectorConfirmationPage",
+                      answers: [
+                        {
+                          qCode: "confirmation-code",
+                          id: "confirmation-answer",
+                          type: "Radio",
+                          options: [
+                            {
+                              id: "confirmation-option-positive",
+                              label: "Yes",
+                            },
+                            {
+                              id: "confirmation-option-negative",
+                              label: "No",
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ]
+                : [
+                    {
+                      id: "page-1",
+                      title: "Question 1",
+                      pageType,
+                      answers: [
+                        {
+                          ...answer,
+                        },
+                      ],
                     },
                   ],
-                },
-              ],
             },
           ],
         },
       ],
       collectionLists: {
         id: "collection-list-1",
-        lists:
-          pageType === "ListCollectorPage"
-            ? [
-                {
-                  id: "list-1",
-                  answers: [
-                    {
-                      ...answer,
-                    },
-                  ],
-                },
-              ]
-            : [],
+        lists: withListCollector
+          ? [
+              {
+                id: "list-1",
+                answers: [
+                  {
+                    ...answer,
+                  },
+                ],
+              },
+            ]
+          : [],
       },
     });
 
@@ -450,30 +501,31 @@ describe("Create answer codes", () => {
   describe("Page types", () => {
     it("should add answer codes for list collector page type", () => {
       const answer = {
-        id: "list-textfield-answer-1",
+        id: "textfield-answer-1",
         type: TEXTFIELD,
         qCode: "list-textfield-answer-code",
       };
 
       const questionnaire = createQuestionnaireJSON(
         answer,
-        "ListCollectorPage"
+        "QuestionPage",
+        true
       );
 
       const answerCodes = createAnswerCodes(questionnaire);
 
       expect(answerCodes).toEqual([
         {
-          answer_id: "answerlist-textfield-answer-1",
+          answer_id: "answerqualifier-answer",
+          code: "qualifier-code",
+        },
+        {
+          answer_id: "answerconfirmation-answer",
+          code: "confirmation-code",
+        },
+        {
+          answer_id: "answertextfield-answer-1",
           code: "list-textfield-answer-code",
-        },
-        {
-          answer_id: "answer-driving-page-1",
-          code: "driving-code",
-        },
-        {
-          answer_id: "add-another-page-1",
-          code: "another-code",
         },
       ]);
     });

--- a/src/utils/createAnswerCodes/index.test.js
+++ b/src/utils/createAnswerCodes/index.test.js
@@ -65,6 +65,16 @@ describe("Create answer codes", () => {
                       pageType: "ListCollectorAddItemPage",
                     },
                     {
+                      id: "additional-page",
+                      title: "Additional question",
+                      pageType,
+                      answers: [
+                        {
+                          ...answer,
+                        },
+                      ],
+                    },
+                    {
                       id: "list-confirmation-page",
                       title: "List confirmation title",
                       pageType: "ListCollectorConfirmationPage",
@@ -514,6 +524,10 @@ describe("Create answer codes", () => {
         {
           answer_id: "answerqualifier-answer",
           code: "qualifier-code",
+        },
+        {
+          answer_id: "answertextfield-answer-1",
+          code: "list-textfield-answer-code",
         },
         {
           answer_id: "answerconfirmation-answer",

--- a/src/utils/createAnswerCodes/index.test.js
+++ b/src/utils/createAnswerCodes/index.test.js
@@ -19,8 +19,8 @@ const {
 describe("Create answer codes", () => {
   const createQuestionnaireJSON = (
     answer,
-    pageType = "QuestionPage",
-    withListCollector
+    withListCollector,
+    pageType = "QuestionPage"
   ) =>
     Object.assign({
       id: "questionnaire-1",
@@ -506,11 +506,7 @@ describe("Create answer codes", () => {
         qCode: "list-textfield-answer-code",
       };
 
-      const questionnaire = createQuestionnaireJSON(
-        answer,
-        "QuestionPage",
-        true
-      );
+      const questionnaire = createQuestionnaireJSON(answer, true);
 
       const answerCodes = createAnswerCodes(questionnaire);
 
@@ -539,6 +535,7 @@ describe("Create answer codes", () => {
 
       const questionnaire = createQuestionnaireJSON(
         answer,
+        false,
         "CalculatedSummaryPage"
       );
       const answerCodes = createAnswerCodes(questionnaire);


### PR DESCRIPTION
### What is the context of this PR?
Adds answer codes for list collector qualifier and confirmation questions
The `answer_id` attributes of these answer codes now follow the same format as answers from question pages, using answer IDs instead of page IDs.

### How to review
**Check:**
- [ ] eQ schema includes list collector qualifier and confirmation answer codes
- [ ] List collector qualifier and confirmation answer codes follow the correct format
- [ ] Collection list answers' answer codes remain unchanged