### PR TITLE
fix for delimters

### DIFF
--- a/src/eq_schema/block-types/Introduction/index.test.js
+++ b/src/eq_schema/block-types/Introduction/index.test.js
@@ -144,7 +144,7 @@ describe("Introduction", () => {
         contents: [
           {
             list: [
-              "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated. ",
+              "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
               "You can provide info estimates if actual figures aren&#x2019;t available.",
               "We will treat your data securely and confidentially.",
               createPipedFormat("some_metadata", "metadata"),

--- a/src/eq_schema/block-types/listCollector/__snapshots__/index.test.js.snap
+++ b/src/eq_schema/block-types/listCollector/__snapshots__/index.test.js.snap
@@ -404,7 +404,7 @@ SummaryBlock {
         "transforms": Array [
           Object {
             "arguments": Object {
-              "delimiter": "&nbsp;",
+              "delimiter": " ",
               "list_to_concatenate": Array [],
             },
             "transform": "concatenate_list",

--- a/src/eq_schema/block-types/listCollector/summaryBlock.js
+++ b/src/eq_schema/block-types/listCollector/summaryBlock.js
@@ -14,7 +14,7 @@ class SummaryBlock {
           transforms: [
             {
               arguments: {
-                delimiter: "&nbsp;",
+                delimiter: " ",
                 list_to_concatenate: this.buildList(listAnswers)
               },
               transform: "concatenate_list"

--- a/src/eq_schema/schema/Section/index.js
+++ b/src/eq_schema/schema/Section/index.js
@@ -49,7 +49,7 @@ class Section {
           transforms: [
             {
               arguments: {
-                delimiter: "&nbsp;",
+                delimiter: " ",
                 list_to_concatenate: this.buildList(list.answers),
               },
               transform: "concatenate_list",

--- a/src/middleware/respondWithData/index.js
+++ b/src/middleware/respondWithData/index.js
@@ -1,8 +1,4 @@
 module.exports = function respondWithData(req, res) {
   const questionnaire = res.locals.questionnaire;
-  const trimmedQuestionnaire = JSON.parse(
-    JSON.stringify(questionnaire).replace(/"\s+|\s+"/g, '"')
-  );
-
-  res.json(trimmedQuestionnaire);
+  res.json(questionnaire);
 };

--- a/src/middleware/respondWithData/index.test.js
+++ b/src/middleware/respondWithData/index.test.js
@@ -16,10 +16,10 @@ describe("fetchData", () => {
     res = {
       locals: {
         questionnaire: {
-          id: "123   ",
+          id: "123",
           sections: [
             {
-              title: "   Whitespaced   "
+              title: "Whitespaced"
             }
           ]
         }

--- a/src/utils/convertPipes/PlaceholderObjectBuilder.js
+++ b/src/utils/convertPipes/PlaceholderObjectBuilder.js
@@ -104,12 +104,12 @@ const placeholderObjectBuilder = (
     }
     if (["Checkbox"].includes(AnswerType)) {
       argumentList = {
-        delimiter: ",&nbsp;",
+        delimiter: ", ",
       };
     }
     if (["array"].includes(AnswerType)) {
       argumentList = {
-        delimiter: ",&nbsp;",
+        delimiter: ", ",
       };
       valueSource = [valueSource];
     }

--- a/src/utils/convertPipes/index.js
+++ b/src/utils/convertPipes/index.js
@@ -241,6 +241,8 @@ const convertPipes = (ctx, isMultipleChoiceValue) => (html) => {
   if (conditionalTradAs) {
     store.text = store.text.replace("({trad_as})", "{trad_as}");
   }
+  
+  store.text = store.text.replace(/\s+$/, '');
 
   if (!store.placeholders.length) {
     return store.text;

--- a/src/utils/convertPipes/index.test.js
+++ b/src/utils/convertPipes/index.test.js
@@ -303,7 +303,7 @@ describe("convertPipes", () => {
                 transform: "concatenate_list",
               },
               {
-                delimiter: ",&nbsp;",
+                delimiter: ", ",
                 list_to_concatenate: {
                   identifier: "answer7",
                   source: "answers",


### PR DESCRIPTION
Currently delimiters are using the HTML code to represent a space in the runner schemas. this effects the presentation of some data in runner. This fix changes it to an ascii space. However this had the knock on effect of whitespace being removed from the attribute and the space going missing i.e ", " was changed to "," 
This fix moves that whitespace trimming into the convertPipes instead of the middleware.