### PR TITLE
EAR 2321 limit character in text field answer

### DIFF
--- a/src/eq_schema/schema/Answer/index.js
+++ b/src/eq_schema/schema/Answer/index.js
@@ -13,6 +13,7 @@ const {
   SELECT,
   DROPDOWN,
   MUTUALLY_EXCLUSIVE,
+  TEXTFIELD,
 } = require("../../../constants/answerTypes");
 const { unitConversion } = require("../../../constants/units");
 const { getValueSource } = require("../../builders/valueSource");
@@ -47,7 +48,7 @@ class Answer {
 
     if (!ctx || (answer.qCode && ctx.questionnaireJson.dataVersion !== "3")) {
       if (answer.type !== CHECKBOX) {
-        this.q_code = answer.qCode.replace(/\s+$/, '');
+        this.q_code = answer.qCode.replace(/\s+$/, "");
       }
     }
 
@@ -74,6 +75,12 @@ class Answer {
 
     if (answer.type === TEXTAREA) {
       if (answer.properties.maxLength) {
+        this.max_length = parseInt(answer.properties.maxLength);
+      }
+    }
+
+    if (answer.type === TEXTFIELD) {
+      if (answer.properties.maxLength && answer.limitCharacter) {
         this.max_length = parseInt(answer.properties.maxLength);
       }
     }
@@ -265,10 +272,16 @@ class Answer {
         id: `answer${additionalAnswer.id}`,
         mandatory: properties.required,
       };
-      option.detail_answer.label = option.detail_answer.label.replace(/\s+$/, '');
+      option.detail_answer.label = option.detail_answer.label.replace(
+        /\s+$/,
+        ""
+      );
       if (ctx.questionnaireJson.dataVersion !== "3") {
         if (additionalAnswer.qCode && type !== "Checkbox") {
-          option.detail_answer.q_code = additionalAnswer.qCode.replace(/\s+$/, '');
+          option.detail_answer.q_code = additionalAnswer.qCode.replace(
+            /\s+$/,
+            ""
+          );
         }
       }
     }

--- a/src/eq_schema/schema/Answer/index.test.js
+++ b/src/eq_schema/schema/Answer/index.test.js
@@ -181,6 +181,32 @@ describe("Answer", () => {
     expect(answer.max_length).toBeUndefined();
   });
 
+  it("should set maxLength property for textfield types when limit character is true", () => {
+    const answer = new Answer(
+      createAnswerJSON({
+        type: TEXTFIELD,
+        properties: {
+          maxLength: "12",
+        },
+        limitCharacter: true,
+      })
+    );
+    expect(answer.max_length).toBe(12);
+  });
+
+  it("should not set the maxLength property for textfield when limit character is false", () => {
+    const answer = new Answer(
+      createAnswerJSON({
+        type: TEXTFIELD,
+        properties: {
+          maxLength: "12",
+        },
+        limitCharacter: false,
+      })
+    );
+    expect(answer.max_length).toBeUndefined();
+  });
+
   describe("validation", () => {
     it("should not add validation if undefined", () => {
       const answer = new Answer(


### PR DESCRIPTION
### **What is the context of this PR?**
Created a toggle switch called Character Limit which allows the user to limit the number of characters the respondent can answer.
eq-author-app: https://github.com/ONSdigital/eq-author-app/pull/3092
ticket: https://jira.ons.gov.uk/browse/EAR-2321

### **How to review**
- Create a questionnaire with text field answer type and turn on the character limit toggle switch. set the Maximum number of characters between 8-100
- View the questionnaire in EQ and ensure that if the value in the answer is above the character limit it displays a warning 
-  Turn off the character limit toggle switch and view in EQ and ensure there is no character limit warning shown. 

