### PR TITLE
EAR 2291 update content for calculated summary question

### DIFF
--- a/src/eq_schema/schema/Block/index.js
+++ b/src/eq_schema/schema/Block/index.js
@@ -119,7 +119,10 @@ class Block {
       this.page_title = processPipe(ctx)(page.pageDescription);
     }
     if (page.pageType === "CalculatedSummaryPage") {
-      this.title = `${processPipe(ctx)(page.title)} Is this correct?`;
+      this.title = processPipe(ctx)(page.title).endsWith(".")
+        ? `${processPipe(ctx)(page.title)} Is this correct?`
+        : `${processPipe(ctx)(page.title)}. Is this correct?`;
+
       this.page_title =
         processPipe(ctx)(page.pageDescription) || processPipe(ctx)(page.title);
 

--- a/src/eq_schema/schema/Block/index.js
+++ b/src/eq_schema/schema/Block/index.js
@@ -119,7 +119,7 @@ class Block {
       this.page_title = processPipe(ctx)(page.pageDescription);
     }
     if (page.pageType === "CalculatedSummaryPage") {
-      this.title = processPipe(ctx)(page.title);
+      this.title = `${processPipe(ctx)(page.title)} Is this correct?`;
       this.page_title =
         processPipe(ctx)(page.pageDescription) || processPipe(ctx)(page.title);
 

--- a/src/eq_schema/schema/Block/index.test.js
+++ b/src/eq_schema/schema/Block/index.test.js
@@ -200,7 +200,7 @@ describe("Block", () => {
           title: "Bye",
         },
         id: "1",
-        title: "Hi is your total %(total)s",
+        title: "Hi is your total %(total)s. Is this correct?",
         type: "CalculatedSummary",
       });
     });
@@ -728,7 +728,7 @@ describe("Block", () => {
           id: "summary-page1",
           type: "CalculatedSummary",
           page_title: "Summary page1",
-          title: "Summary1",
+          title: "Summary1. Is this correct?",
           calculation: {
             operation: {
               "+": [
@@ -750,6 +750,49 @@ describe("Block", () => {
                 ["No"],
               ],
             },
+          },
+        });
+      });
+
+      it("Should not add a full stop after the title if it has been added by the user", () => {
+        const calculatedPageGraphql = {
+          totalTitle: "<p>Summary title1</p>",
+          answers: [
+            {
+              label: "<p>Summary title1</p>",
+              type: "Number",
+              id: "9d2b3354-9751-4be4-9523-1f36345c3069",
+              validation: {},
+              properties: {},
+            },
+          ],
+          title: "<p>Summary1.</p>",
+          type: "Number",
+          pageType: "CalculatedSummaryPage",
+          summaryAnswers: ["num-1"],
+          pageDescription: "Summary page1",
+          alias: null,
+          id: "summary-page1",
+          listId: undefined,
+        };
+
+        const block = new Block(calculatedPageGraphql, null, ctx);
+
+        expect(block).toMatchObject({
+          id: "summary-page1",
+          type: "CalculatedSummary",
+          page_title: "Summary page1",
+          title: "Summary1. Is this correct?",
+          calculation: {
+            operation: {
+              "+": [
+                {
+                  identifier: "answernum-1",
+                  source: "answers",
+                },
+              ],
+            },
+            title: "Summary title1",
           },
         });
       });
@@ -782,7 +825,7 @@ describe("Block", () => {
           id: "summary-page1",
           type: "CalculatedSummary",
           page_title: "Summary page1",
-          title: "Summary1",
+          title: "Summary1. Is this correct?",
           calculation: {
             operation: {
               "+": [
@@ -829,7 +872,7 @@ describe("Block", () => {
           id: "grand-summary-1",
           type: "GrandCalculatedSummary",
           page_title: "Grand summary",
-          title: "Grand summary",
+          title: "Grand summary. Is this correct?",
           calculation: {
             operation: {
               "+": [


### PR DESCRIPTION
### Context 
To update the preview and EQ of calculated summary page by adding a button and the text "Is this correct" of the title 
ticket: https://jira.ons.gov.uk/browse/EAR-2291
EQ-author-app: https://github.com/ONSdigital/eq-author-app/pull/3098

### How to review 
- [ ]  create a questionnaire with calculated summary page 
- [ ]  Ensure 2 questions are created within the calculated summary page
- [ ]  In the calculated summary title add a title without a full-spot
- [ ]  View in EQ and check if there is a full spot after a title and the text "Is this correct"?
- [ ]  Go back to the calculated summary title and add a full spot in the title 
- [ ] Then view in EQ again and check that the full spot is not repeated after the title and check the text "Is this correct"?