### PR TITLE
repeating answers and empty list collectors

### DIFF
--- a/src/utils/functions/pageGetters.js
+++ b/src/utils/functions/pageGetters.js
@@ -1,3 +1,10 @@
+const { flatMap, filter } = require("lodash");
+
+const getPages = (ctx) =>
+  flatMap(ctx.questionnaireJson.sections, (section) =>
+    flatMap(section.folders, ({ pages }) => pages)
+  );
+
 const getPageById = (ctx, pageId) => {
   let result;
   ctx.questionnaireJson.sections.forEach((section) => {
@@ -13,4 +20,9 @@ const getPageById = (ctx, pageId) => {
   return result;
 };
 
-module.exports = { getPageById };
+const getPagesByListId = (ctx, listId) => 
+  flatMap(ctx.questionnaireJson.sections, (section) =>
+    flatMap(filter(section.folders, { listId:listId }), ({ pages }) => pages)
+  );
+
+module.exports = { getPageById, getPagesByListId, getPages };


### PR DESCRIPTION
Changed the approach to dealing with empty lists and repeating answers.

The current approach meant Runner limitations didn't clear out answers if the respondent changed their answer 