### PR TITLE
EAR-2403 fix for piping grand calc summary

### DIFF
--- a/src/eq_schema/builders/valueSource/index.js
+++ b/src/eq_schema/builders/valueSource/index.js
@@ -14,7 +14,9 @@ const getPageByAnswerId = (ctx, answerId) =>
 const getValueSource = (ctx, sourceId) => {
   const page = getPageByAnswerId(ctx, sourceId);
   if (page && page.pageType === "CalculatedSummaryPage") {
-    const calcSumAnswers = flatMap(page.summaryAnswers, (answerId) => getPageByAnswerId(ctx, answerId));
+    const calcSumAnswers = flatMap(page.summaryAnswers, (answerId) =>
+      getPageByAnswerId(ctx, answerId)
+    );
     if (some(calcSumAnswers, { pageType: "CalculatedSummaryPage" })) {
       return {
         identifier: page.id,
@@ -33,18 +35,22 @@ const getValueSource = (ctx, sourceId) => {
 };
 
 const getSupplementaryValueSource = (ctx, sourceId) => {
-  const suplementaryField = find(flatMap(ctx.questionnaireJson.supplementaryData.data, "schemaFields"), { id: sourceId });
+  const suplementaryField = find(
+    flatMap(ctx.questionnaireJson.supplementaryData.data, "schemaFields"),
+    { id: sourceId }
+  );
   const source = {
     source: "supplementary_data",
-    identifier: suplementaryField.identifier
+    identifier: suplementaryField.identifier,
   };
   if (suplementaryField.selector) {
-    source.selectors = [suplementaryField.selector]
-  };
+    source.selectors = [suplementaryField.selector];
+  }
 
   return source;
-}
+};
 
 module.exports = {
-  getValueSource, getSupplementaryValueSource
+  getValueSource,
+  getSupplementaryValueSource,
 };

--- a/src/eq_schema/builders/valueSource/index.js
+++ b/src/eq_schema/builders/valueSource/index.js
@@ -14,7 +14,7 @@ const getPageByAnswerId = (ctx, answerId) =>
 const getValueSource = (ctx, sourceId) => {
   const page = getPageByAnswerId(ctx, sourceId);
   if (page && page.pageType === "CalculatedSummaryPage") {
-    const calcSumAnswers = flatMap(page.summaryAnswers, (answerId) => getPageByAnswerId(ctx, answerId))
+    const calcSumAnswers = flatMap(page.summaryAnswers, (answerId) => getPageByAnswerId(ctx, answerId));
     if (some(calcSumAnswers, { pageType: "CalculatedSummaryPage" })) {
       return {
         identifier: page.id,
@@ -37,10 +37,10 @@ const getSupplementaryValueSource = (ctx, sourceId) => {
   const source = {
     source: "supplementary_data",
     identifier: suplementaryField.identifier
-  }
+  };
   if (suplementaryField.selector) {
     source.selectors = [suplementaryField.selector]
-  }
+  };
 
   return source;
 }

--- a/src/eq_schema/builders/valueSource/index.js
+++ b/src/eq_schema/builders/valueSource/index.js
@@ -13,18 +13,18 @@ const getPageByAnswerId = (ctx, answerId) =>
 
 const getValueSource = (ctx, sourceId) => {
   const page = getPageByAnswerId(ctx, sourceId);
-  if (page && page.pageType === "CalculatedSummaryPage") { 
-      const calcSumAnswers = flatMap(page.summaryAnswers, (answerId) => getPageByAnswerId(ctx, answerId))
-      if (some(calcSumAnswers, {pageType: "CalculatedSummaryPage"})) {
-        return {
-          identifier: page.id,
-          source: "grand_calculated_summary",
-        };
-      }
+  if (page && page.pageType === "CalculatedSummaryPage") {
+    const calcSumAnswers = flatMap(page.summaryAnswers, (answerId) => getPageByAnswerId(ctx, answerId))
+    if (some(calcSumAnswers, { pageType: "CalculatedSummaryPage" })) {
       return {
         identifier: page.id,
-        source: "calculated_summary",
+        source: "grand_calculated_summary",
       };
+    }
+    return {
+      identifier: page.id,
+      source: "calculated_summary",
+    };
   }
   return {
     identifier: `answer${sourceId}`,
@@ -33,7 +33,7 @@ const getValueSource = (ctx, sourceId) => {
 };
 
 const getSupplementaryValueSource = (ctx, sourceId) => {
-  const suplementaryField = find(flatMap(ctx.questionnaireJson.supplementaryData.data, "schemaFields"), {id: sourceId});
+  const suplementaryField = find(flatMap(ctx.questionnaireJson.supplementaryData.data, "schemaFields"), { id: sourceId });
   const source = {
     source: "supplementary_data",
     identifier: suplementaryField.identifier
@@ -41,7 +41,7 @@ const getSupplementaryValueSource = (ctx, sourceId) => {
   if (suplementaryField.selector) {
     source.selectors = [suplementaryField.selector]
   }
-  
+
   return source;
 }
 

--- a/src/eq_schema/builders/valueSource/index.js
+++ b/src/eq_schema/builders/valueSource/index.js
@@ -13,13 +13,18 @@ const getPageByAnswerId = (ctx, answerId) =>
 
 const getValueSource = (ctx, sourceId) => {
   const page = getPageByAnswerId(ctx, sourceId);
-  if (page) {
-    if (page.pageType === "CalculatedSummaryPage") {
+  if (page && page.pageType === "CalculatedSummaryPage") { 
+      const calcSumAnswers = flatMap(page.summaryAnswers, (answerId) => getPageByAnswerId(ctx, answerId))
+      if (some(calcSumAnswers, {pageType: "CalculatedSummaryPage"})) {
+        return {
+          identifier: page.id,
+          source: "grand_calculated_summary",
+        };
+      }
       return {
         identifier: page.id,
         source: "calculated_summary",
       };
-    }
   }
   return {
     identifier: `answer${sourceId}`,


### PR DESCRIPTION
Jira - https://jira.ons.gov.uk/browse/EAR-2403

Issue - When piping a grand calc summary, the value source type should be grand_calculated_summary and not calculated summary,

These changes check whether the referenced answers in the calc summary come from a page that is also a calculated summary making it a grand calc summary