### PR TITLE
EAR-2439 mutually exclusive logic not applied when mutually exclusive answer has only one option

### DIFF
--- a/src/eq_schema/builders/basicQuestionnaireJSON.js
+++ b/src/eq_schema/builders/basicQuestionnaireJSON.js
@@ -92,6 +92,43 @@ const questionnaireJson = {
         },
       ],
     },
+
+    {
+      id: "3",
+      title: "<p>Section 3</p>",
+      folders: [
+        {
+          id: "folder-3",
+          enabled: false,
+          pages: [
+            {
+              id: "4",
+              title: "<p>Page 4</p>",
+              pageType: "QuestionPage",
+              routingRuleSet: null,
+              confirmation: null,
+              answers: [
+                {
+                  id: "5",
+                  type: "Number",
+                  label: "Answer 5",
+                },
+                {
+                  id: "6",
+                  type: "MutuallyExclusive",
+                  options: [
+                    {
+                      id: "exclusive-option-1",
+                      label: "Not known",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
   ],
 };
 

--- a/src/eq_schema/builders/basicQuestionnaireJSON.js
+++ b/src/eq_schema/builders/basicQuestionnaireJSON.js
@@ -92,7 +92,6 @@ const questionnaireJson = {
         },
       ],
     },
-
     {
       id: "3",
       title: "<p>Section 3</p>",

--- a/src/eq_schema/builders/routing2/newRoutingDestination/index.js
+++ b/src/eq_schema/builders/routing2/newRoutingDestination/index.js
@@ -62,22 +62,6 @@ const checkType = (type) => {
   return null;
 };
 
-// const containsMutuallyExclusive = (obj, answerId) => {
-//   // Flatten the nested arrays of sections, folders, pages, and answers
-//   const answers = flatMap(obj.sections, (section) =>
-//     flatMap(section.folders, (folder) =>
-//       flatMap(folder.pages, (page) => page.answers)
-//     )
-//   );
-
-//   // Find the mutually exclusive answer
-//   return (
-//     answers.find(
-//       (answer) => answer.id === answerId && answer.type === "MutuallyExclusive"
-//     ) || null
-//   );
-// };
-
 const buildAnswerObject = (
   { left, condition, secondaryCondition, right },
   ctx

--- a/src/eq_schema/builders/routing2/newRoutingDestination/index.js
+++ b/src/eq_schema/builders/routing2/newRoutingDestination/index.js
@@ -61,7 +61,7 @@ const checkType = (type) => {
   return null;
 };
 
-function containsMutuallyExclusive(obj) {
+const containsMutuallyExclusive = (obj) => {
   if (typeof obj !== "object" || obj === null) {
     return false;
   }
@@ -74,10 +74,10 @@ function containsMutuallyExclusive(obj) {
     return true;
   }
 
-  // console.log(Object.values(obj).some(containsMutuallyExclusive));
+  console.log(Object.values(obj).some(containsMutuallyExclusive));
 
   return Object.values(obj).some(containsMutuallyExclusive);
-}
+};
 
 const buildAnswerObject = (
   { left, condition, secondaryCondition, right },

--- a/src/eq_schema/builders/routing2/newRoutingDestination/index.js
+++ b/src/eq_schema/builders/routing2/newRoutingDestination/index.js
@@ -62,21 +62,21 @@ const checkType = (type) => {
   return null;
 };
 
-const containsMutuallyExclusive = (obj, answerId) => {
-  // Flatten the nested arrays of sections, folders, pages, and answers
-  const answers = flatMap(obj.sections, (section) =>
-    flatMap(section.folders, (folder) =>
-      flatMap(folder.pages, (page) => page.answers)
-    )
-  );
+// const containsMutuallyExclusive = (obj, answerId) => {
+//   // Flatten the nested arrays of sections, folders, pages, and answers
+//   const answers = flatMap(obj.sections, (section) =>
+//     flatMap(section.folders, (folder) =>
+//       flatMap(folder.pages, (page) => page.answers)
+//     )
+//   );
 
-  // Find the mutually exclusive answer
-  return (
-    answers.find(
-      (answer) => answer.id === answerId && answer.type === "MutuallyExclusive"
-    ) || null
-  );
-};
+//   // Find the mutually exclusive answer
+//   return (
+//     answers.find(
+//       (answer) => answer.id === answerId && answer.type === "MutuallyExclusive"
+//     ) || null
+//   );
+// };
 
 const buildAnswerObject = (
   { left, condition, secondaryCondition, right },
@@ -152,17 +152,19 @@ const buildAnswerObject = (
         const SelectedOptions = {
           [routingConditionConversion("AllOf")]: optionValues,
         };
+
+        return SelectedOptions;
+      } else {
+        const swapOptionValues = ([optionValues[0], optionValues[1]] = [
+          optionValues[1],
+          optionValues[0],
+        ]);
+        const SelectedOptions = {
+          [routingConditionConversion(condition)]: swapOptionValues,
+        };
+
         return SelectedOptions;
       }
-      const swapOptionValues = ([optionValues[0], optionValues[1]] = [
-        optionValues[1],
-        optionValues[0],
-      ]);
-      const SelectedOptions = {
-        [routingConditionConversion(condition)]: swapOptionValues,
-      };
-
-      return SelectedOptions;
     }
 
     const SelectedOptions = {

--- a/src/eq_schema/builders/routing2/newRoutingDestination/index.js
+++ b/src/eq_schema/builders/routing2/newRoutingDestination/index.js
@@ -6,6 +6,7 @@ const { getValueSource } = require("../../valueSource");
 const { getListFromAll } = require("../../../../utils/functions/listGetters");
 
 const { flatMap, filter, find } = require("lodash");
+const { getAnswerByID } = require("../../../../utils/functions/answerGetters");
 
 const authorConditions = {
   UNANSWERED: "Unanswered",
@@ -90,6 +91,7 @@ const buildAnswerObject = (
       },
     ];
   }
+  // console.log(getAnswerByID(ctx, "ccde1be3-ba11-4481-9c4c-5a7a9cae6ce8"));
 
   if (right === null) {
     returnVal.push(null);
@@ -138,10 +140,14 @@ const buildAnswerObject = (
       return SelectedOptions;
     }
 
+    const leftSideAnswer = getAnswerByID(ctx, left.answerId);
+    // console.log("Hello1", leftSideAnswer.type);
+    // console.log("Hello2", leftSideAnswer.options.length);
+
     if (condition === "OneOf") {
       if (
-        containsMutuallyExclusive(ctx.questionnaireJson, left.answerId) &&
-        optionValues[0].length === 1
+        leftSideAnswer.type === "MutuallyExclusive" &&
+        leftSideAnswer.options.length === 1
       ) {
         const SelectedOptions = {
           [routingConditionConversion("AllOf")]: optionValues,

--- a/src/eq_schema/builders/routing2/newRoutingDestination/index.js
+++ b/src/eq_schema/builders/routing2/newRoutingDestination/index.js
@@ -6,7 +6,7 @@ const { getValueSource } = require("../../valueSource");
 const { getListFromAll } = require("../../../../utils/functions/listGetters");
 
 const { flatMap, filter, find } = require("lodash");
-const { getAnswerByID } = require("../../../../utils/functions/answerGetters");
+const { getAnswerById } = require("../../../../utils/functions/answerGetters");
 
 const authorConditions = {
   UNANSWERED: "Unanswered",
@@ -91,7 +91,6 @@ const buildAnswerObject = (
       },
     ];
   }
-  // console.log(getAnswerByID(ctx, "ccde1be3-ba11-4481-9c4c-5a7a9cae6ce8"));
 
   if (right === null) {
     returnVal.push(null);
@@ -140,12 +139,11 @@ const buildAnswerObject = (
       return SelectedOptions;
     }
 
-    const leftSideAnswer = getAnswerByID(ctx, left.answerId);
-    // console.log("Hello1", leftSideAnswer.type);
-    // console.log("Hello2", leftSideAnswer.options.length);
+    const leftSideAnswer = getAnswerById(ctx, left.answerId);
 
     if (condition === "OneOf") {
       if (
+        leftSideAnswer &&
         leftSideAnswer.type === "MutuallyExclusive" &&
         leftSideAnswer.options.length === 1
       ) {

--- a/src/eq_schema/builders/routing2/newRoutingDestination/index.js
+++ b/src/eq_schema/builders/routing2/newRoutingDestination/index.js
@@ -74,8 +74,6 @@ const containsMutuallyExclusive = (obj) => {
     return true;
   }
 
-  console.log(Object.values(obj).some(containsMutuallyExclusive));
-
   return Object.values(obj).some(containsMutuallyExclusive);
 };
 
@@ -149,9 +147,6 @@ const buildAnswerObject = (
         [routingConditionConversion("AllOf")]: optionValues,
       };
 
-      console.log(optionValues);
-      console.log("Hello", SelectedOptions);
-
       return SelectedOptions;
     } else if (condition === "OneOf") {
       const swapOptionValues = ([optionValues[0], optionValues[1]] = [
@@ -162,23 +157,8 @@ const buildAnswerObject = (
         [routingConditionConversion(condition)]: swapOptionValues,
       };
 
-      // let a = containsMutuallyExclusive(ctx.questionnaireJson);
-      // console.log(a);
-
       return SelectedOptions;
     }
-
-    // if (
-    //   condition === "OneOf" &&
-    //   containsMutuallyExclusive(ctx.questionnaireJson) === true
-    // ) {
-    //   const SelectedOptions = {
-    //     [routingConditionConversion("AllOf")]: optionValues,
-    //   };
-    //   console.log("Hello", SelectedOptions);
-
-    //   return SelectedOptions;
-    // }
 
     const SelectedOptions = {
       [routingConditionConversion(condition)]: optionValues,

--- a/src/eq_schema/builders/routing2/newRoutingDestination/index.js
+++ b/src/eq_schema/builders/routing2/newRoutingDestination/index.js
@@ -141,7 +141,7 @@ const buildAnswerObject = (
     if (
       condition === "OneOf" &&
       containsMutuallyExclusive(ctx.questionnaireJson) &&
-      optionValues[0].length < 2
+      optionValues[0].length === 1
     ) {
       const SelectedOptions = {
         [routingConditionConversion("AllOf")]: optionValues,

--- a/src/eq_schema/builders/routing2/newRoutingDestination/index.js
+++ b/src/eq_schema/builders/routing2/newRoutingDestination/index.js
@@ -61,22 +61,6 @@ const checkType = (type) => {
   return null;
 };
 
-// const containsMutuallyExclusive = (obj, answerId) => {
-//   for (const section of obj.sections) {
-//     for (const folder of section.folders) {
-//       for (const page of folder.pages) {
-//         for (const answer of page.answers) {
-//           if (answer.id === answerId && answer.type === "MutuallyExclusive") {
-//             console.log(answer);
-//             return answer;
-//           }
-//         }
-//       }
-//     }
-//   }
-//   return null;
-// };
-
 const containsMutuallyExclusive = (obj, answerId) => {
   // Flatten the nested arrays of sections, folders, pages, and answers
   const answers = flatMap(obj.sections, (section) =>
@@ -155,9 +139,6 @@ const buildAnswerObject = (
     }
 
     if (condition === "OneOf") {
-      // console.log(
-      //   containsMutuallyExclusive(ctx.questionnaireJson, left.answerId)
-      // );
       if (
         containsMutuallyExclusive(ctx.questionnaireJson, left.answerId) &&
         optionValues[0].length === 1

--- a/src/eq_schema/builders/routing2/newRoutingDestination/index.js
+++ b/src/eq_schema/builders/routing2/newRoutingDestination/index.js
@@ -61,6 +61,24 @@ const checkType = (type) => {
   return null;
 };
 
+function containsMutuallyExclusive(obj) {
+  if (typeof obj !== "object" || obj === null) {
+    return false;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.some(containsMutuallyExclusive);
+  }
+
+  if (obj.type === "MutuallyExclusive") {
+    return true;
+  }
+
+  // console.log(Object.values(obj).some(containsMutuallyExclusive));
+
+  return Object.values(obj).some(containsMutuallyExclusive);
+}
+
 const buildAnswerObject = (
   { left, condition, secondaryCondition, right },
   ctx
@@ -122,7 +140,17 @@ const buildAnswerObject = (
       return SelectedOptions;
     }
 
-    if (condition === "OneOf") {
+    if (
+      condition === "OneOf" &&
+      containsMutuallyExclusive(ctx.questionnaireJson)
+    ) {
+      const SelectedOptions = {
+        [routingConditionConversion("AllOf")]: optionValues,
+      };
+      console.log("Hello", SelectedOptions);
+
+      return SelectedOptions;
+    } else if (condition === "OneOf") {
       const swapOptionValues = ([optionValues[0], optionValues[1]] = [
         optionValues[1],
         optionValues[0],
@@ -131,8 +159,23 @@ const buildAnswerObject = (
         [routingConditionConversion(condition)]: swapOptionValues,
       };
 
+      // let a = containsMutuallyExclusive(ctx.questionnaireJson);
+      // console.log(a);
+
       return SelectedOptions;
     }
+
+    // if (
+    //   condition === "OneOf" &&
+    //   containsMutuallyExclusive(ctx.questionnaireJson) === true
+    // ) {
+    //   const SelectedOptions = {
+    //     [routingConditionConversion("AllOf")]: optionValues,
+    //   };
+    //   console.log("Hello", SelectedOptions);
+
+    //   return SelectedOptions;
+    // }
 
     const SelectedOptions = {
       [routingConditionConversion(condition)]: optionValues,

--- a/src/eq_schema/builders/routing2/newRoutingDestination/index.js
+++ b/src/eq_schema/builders/routing2/newRoutingDestination/index.js
@@ -142,11 +142,14 @@ const buildAnswerObject = (
 
     if (
       condition === "OneOf" &&
-      containsMutuallyExclusive(ctx.questionnaireJson)
+      containsMutuallyExclusive(ctx.questionnaireJson) &&
+      optionValues[0].length < 2
     ) {
       const SelectedOptions = {
         [routingConditionConversion("AllOf")]: optionValues,
       };
+
+      console.log(optionValues);
       console.log("Hello", SelectedOptions);
 
       return SelectedOptions;

--- a/src/eq_schema/builders/routing2/newRoutingDestination/index.test.js
+++ b/src/eq_schema/builders/routing2/newRoutingDestination/index.test.js
@@ -181,6 +181,36 @@ describe("Should build a runner representation of a binary expression", () => {
     });
   });
 
+  describe("With mutually exclusive answers", () => {
+    it("should return all of condition for mutually exclusive answers with one option", () => {
+      const expression = {
+        left: {
+          answerId: "6",
+          type: "Answer",
+        },
+        condition: "OneOf",
+        right: {
+          type: "SelectedOptions",
+          optionIds: ["exclusive-option-1"],
+        },
+      };
+
+      const runnerExpression = checkValidRoutingType(expression, {
+        questionnaireJson,
+      });
+
+      expect(runnerExpression).toMatchObject({
+        "all-in": [
+          ["Not known"],
+          {
+            identifier: "answer6",
+            source: "answers",
+          },
+        ],
+      });
+    });
+  });
+
   describe("With metadata", () => {
     describe("Text metadata", () => {
       it("should return correct metadata object for text metadata", () => {

--- a/src/eq_schema/builders/routing2/translateRoutingDestination/index.test.js
+++ b/src/eq_schema/builders/routing2/translateRoutingDestination/index.test.js
@@ -57,7 +57,7 @@ describe("Translation of a routing destination", () => {
       logical: "NextPage",
     };
     expect(
-      translateRoutingDestination(authorDestination, "3", { questionnaireJson })
+      translateRoutingDestination(authorDestination, "4", { questionnaireJson })
     ).toMatchObject({ group: "confirmation-group" });
   });
 
@@ -66,7 +66,7 @@ describe("Translation of a routing destination", () => {
       logical: "NextPage",
     };
     expect(
-      translateRoutingDestination(authorDestination, "3", {
+      translateRoutingDestination(authorDestination, "4", {
         questionnaireJson: questionnaireJsonWithSummary,
       })
     ).toMatchObject({ group: "summary-group" });

--- a/src/utils/functions/answerGetters.js
+++ b/src/utils/functions/answerGetters.js
@@ -1,0 +1,14 @@
+const { getPages } = require("./pageGetters.js");
+const { flatMap } = require("lodash");
+
+const getAnswerByID = (ctx, answerId) => {
+  //   console.log(answerId);
+  const pages = getPages(ctx);
+  //   console.log(pages);
+  const answers = flatMap(pages, (page) => page.answers);
+  //   console.log(answers);
+  // Find the answer object by ID
+  return answers.find((answer) => answer.id === answerId) || null;
+};
+
+module.exports = { getAnswerByID };

--- a/src/utils/functions/answerGetters.js
+++ b/src/utils/functions/answerGetters.js
@@ -1,14 +1,11 @@
-const { getPages } = require("./pageGetters.js");
+const { getPages } = require("./pageGetters");
 const { flatMap } = require("lodash");
 
-const getAnswerByID = (ctx, answerId) => {
-  //   console.log(answerId);
+const getAnswerById = (ctx, answerId) => {
   const pages = getPages(ctx);
-  //   console.log(pages);
   const answers = flatMap(pages, (page) => page.answers);
-  //   console.log(answers);
-  // Find the answer object by ID
-  return answers.find((answer) => answer.id === answerId) || null;
+
+  return answers.find((answer) => answer.id === answerId);
 };
 
-module.exports = { getAnswerByID };
+module.exports = { getAnswerById };

--- a/src/utils/functions/answerGetters.test.js
+++ b/src/utils/functions/answerGetters.test.js
@@ -1,0 +1,37 @@
+const { getAnswerById } = require("./answerGetters");
+
+describe("getAnswerById", () => {
+  it("should return an answer by id", () => {
+    const ctx = {
+      questionnaireJson: {
+        sections: [
+          {
+            folders: [
+              {
+                pages: [
+                  {
+                    answers: [
+                      {
+                        id: "1",
+                        label: "Answer 1",
+                      },
+                      {
+                        id: "2",
+                        label: "Answer 2",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    expect(getAnswerById(ctx, "2")).toMatchObject({
+      id: "2",
+      label: "Answer 2",
+    });
+  });
+});


### PR DESCRIPTION
## What is the context of this PR?
Mutually exclusive logic is not applied when a mutually exclusive answer has only one option.

JIRA ticket: https://jira.ons.gov.uk/browse/EAR-2439

### Credit to @Farhanam76 for helping me understand the Author product, giving me the context of the Author product, and the codebase, coming up with the initial logic to solve this issue and letting me work on this ticket with her.

## Bug
### Reproduce for reviews
-  Design a question, have a textarea answer, then have a mutually exclusive answer (OR answer field in Author) and have only one answer option for the mutually exclusive.
-  Add the routing logic rule of `Match OneOf` and select the exclusive answer (OR answer) option.
- Then select a page to go to if the exclusive answer checkbox is ticked.
-  Else go to the end of the current section.

When you do this currently, there is a bug where if you enter something in the textarea, it will go to the end of the current section page as it should. If you tick the checkbox, it should go to the page configured in the routing logic rule but currently, it doesn't and goes to the end of the current section page (the bug).

This is not an issue if there are multiple answer options for the exclusive answer (OR answer) as it'll become radio buttons instead of a checkbox (happens when you only have one answer option for the exclusive answer field).

### What to do after everything is green

1. - [ ] Bring this branch up-to-date with Origin/Master
2. - [ ] If there are a lot of commits or some are not helpful to read, squash them down
3. - [ ] Click the **Merge** button on this pull request
4. - [ ] Does this change mean the **Capability examples** questionnaire should be updated?
5. - [ ] Move the Jira ticket for this task into the next stage of the process

## Fix
-  File changed: `src/eq_schema/builders/routing2/newRoutingDestination/index.js`
- Nested if statement added under `if (condition === "OneOf")` to check if the answer object contains `type:"MutuallyExclusive"` and if the options length === 1
  - If the above conditions are met AllOf passed into `routingConditionConversion` instead of OneOf to fix this bug.
- Created a new file called `utils/functions/answerGetters.js` and it has a reusable function called `getAnswerById` to retrieve the answer object by using the answer ID.
