### PR TITLE
Codeowners eq-author 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ONSdigital/eq-author


### PR DESCRIPTION
### Motivation and Context

Make sure we are meeting github standards, codeowner files are added to all our repo

### What has changed

Created CODEOWNERS file for all eq-author repositories with eq-author team as its owners.

### How to test?
Confirm that the CODEOWNERS file is present in the repository.
Ensure that eq-author is correctly assigned as the codeowners

### Links
https://jira.ons.gov.uk/browse/EAR-2558

### Screenshots (if appropriate):
