### PR TITLE
Fix routing with list collector

### DIFF
--- a/src/eq_schema/builders/routing2/newRoutingDestination/index.test.js
+++ b/src/eq_schema/builders/routing2/newRoutingDestination/index.test.js
@@ -51,6 +51,83 @@ describe("Should build a runner representation of a binary expression", () => {
         });
       });
 
+      it("should build logic rule in questionnaires containing a page without answers", () => {
+        const expression = buildBinaryExpression(["123"], "OneOf");
+        const runnerExpression = checkValidRoutingType(expression, {
+          questionnaireJson: {
+            sections: [
+              {
+                id: "section-1",
+                title: "Section 1",
+                folders: [
+                  {
+                    id: "list-collector-folder-1",
+                    listId: "list-1",
+                    pages: [
+                      {
+                        id: "list-collector-qualifier-page-1",
+                        title: "Qualifier page 1",
+                        answers: [
+                          {
+                            id: "qualifier-answer-1",
+                            type: "Radio",
+                            options: [
+                              {
+                                id: "qualifier-option-1",
+                                label: "Yes",
+                              },
+                              {
+                                id: "qualifier-option-2",
+                                label: "No",
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      {
+                        id: "list-collector-add-item-page-1",
+                        title: "Add item page 1",
+                      },
+                      {
+                        id: "list-collector-confirmation-page-1",
+                        title: "Confirmation page 1",
+                        answers: [
+                          {
+                            id: "confirmation-answer-1",
+                            type: "Radio",
+                            options: [
+                              {
+                                id: "confirmation-option-1",
+                                label: "Yes",
+                              },
+                              {
+                                id: "confirmation-option-2",
+                                label: "No",
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+              ...questionnaireJson.sections,
+            ],
+          },
+        });
+
+        expect(runnerExpression).toMatchObject({
+          in: [
+            {
+              identifier: "answer1",
+              source: "answers",
+            },
+            ["red"],
+          ],
+        });
+      });
+
       it("With a radio answer and no selected options", () => {
         const expression = buildBinaryExpression(["123", "456"], "Unanswered");
         const runnerExpression = checkValidRoutingType(expression, {

--- a/src/utils/functions/answerGetters.js
+++ b/src/utils/functions/answerGetters.js
@@ -5,7 +5,11 @@ const getAnswerById = (ctx, answerId) => {
   const pages = getPages(ctx);
   const answers = flatMap(pages, (page) => page.answers);
 
-  return answers.find((answer) => answer && answer.id === answerId);
+  const resultAnswer = answers.find(
+    (answer) => answer && answer.id === answerId
+  );
+
+  return resultAnswer;
 };
 
 module.exports = { getAnswerById };

--- a/src/utils/functions/answerGetters.js
+++ b/src/utils/functions/answerGetters.js
@@ -5,7 +5,7 @@ const getAnswerById = (ctx, answerId) => {
   const pages = getPages(ctx);
   const answers = flatMap(pages, (page) => page.answers);
 
-  return answers.find((answer) => answer.id === answerId);
+  return answers.find((answer) => answer && answer.id === answerId);
 };
 
 module.exports = { getAnswerById };

--- a/src/utils/functions/answerGetters.test.js
+++ b/src/utils/functions/answerGetters.test.js
@@ -34,4 +34,40 @@ describe("getAnswerById", () => {
       label: "Answer 2",
     });
   });
+
+  it("should return an answer by id when questionnaire contains pages without answers", () => {
+    const ctx = {
+      questionnaireJson: {
+        sections: [
+          {
+            id: "section-1",
+            folders: [
+              {
+                id: "folder-1",
+                pages: [
+                  {
+                    id: "page-1",
+                    answers: [
+                      {
+                        id: "answer-1",
+                        label: "Answer 1",
+                      },
+                    ],
+                  },
+                  {
+                    id: "page-2",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    expect(getAnswerById(ctx, "answer-1")).toMatchObject({
+      id: "answer-1",
+      label: "Answer 1",
+    });
+  });
 });


### PR DESCRIPTION
### What is the context of this PR?

Fixes an error being displayed in Runner when a questionnaire is launched containing both a list collector folder and logic based on a multiple choice answer

### How to review

- Create a questionnaire with a list collector folder
- Add a page with a radio answer after the list collector folder
- Apply routing logic based on the radio answer
- Check that the questionnaire launches in eQ without an error, and that the routing logic is applied correctly