### PR TITLE
added repeating section check to block

### DIFF
--- a/src/eq_schema/schema/Block/index.js
+++ b/src/eq_schema/schema/Block/index.js
@@ -28,7 +28,11 @@ const pageTypeMappings = {
 
 const getLastPage = flow(getOr([], "pages"), last);
 
-const processPipe = (ctx) => flow(convertPipes(ctx), getInnerHTMLWithPiping);
+const processPipe = (ctx, isMultipleChoiceValue = false, isRepeatingSection = false) =>
+  flow(
+    convertPipes(ctx, isMultipleChoiceValue, isRepeatingSection),
+    getInnerHTMLWithPiping
+  );
 
 const reversePipe = (ctx) =>
   flow(wrapContents("contents"), reversePipeContent(ctx));
@@ -91,14 +95,15 @@ class Block {
     introductionTitle,
     introductionContent,
     introductionPageDescription,
+    isRepeatingSection,
     ctx
   ) {
     return {
       type: "Interstitial",
       id: `${formatPageDescription(introductionPageDescription)}`,
-      page_title: processPipe(ctx)(introductionPageDescription),
+      page_title: processPipe(ctx, false, isRepeatingSection)(introductionPageDescription),
       content: {
-        title: processPipe(ctx)(introductionTitle) || "",
+        title: processPipe(ctx, false, isRepeatingSection)(introductionTitle) || "",
         contents: reversePipe(ctx)(introductionContent).contents,
       },
     };

--- a/src/eq_schema/schema/Block/index.js
+++ b/src/eq_schema/schema/Block/index.js
@@ -34,8 +34,8 @@ const processPipe = (ctx, isMultipleChoiceValue = false, isRepeatingSection = fa
     getInnerHTMLWithPiping
   );
 
-const reversePipe = (ctx) =>
-  flow(wrapContents("contents"), reversePipeContent(ctx));
+const reversePipe = (ctx, isMultipleChoiceValue = false, isRepeatingSection = false) =>
+  flow(wrapContents("contents"), reversePipeContent(ctx, isMultipleChoiceValue, isRepeatingSection));
 
 const isLastPageInSection = (page, ctx) =>
   flow(getOr([], "sections"), map(getLastPage), some({ id: page.id }))(ctx);
@@ -104,7 +104,7 @@ class Block {
       page_title: processPipe(ctx, false, isRepeatingSection)(introductionPageDescription),
       content: {
         title: processPipe(ctx, false, isRepeatingSection)(introductionTitle) || "",
-        contents: reversePipe(ctx)(introductionContent).contents,
+        contents: reversePipe(ctx, false, isRepeatingSection)(introductionContent).contents,
       },
     };
   }

--- a/src/eq_schema/schema/Block/index.test.js
+++ b/src/eq_schema/schema/Block/index.test.js
@@ -145,6 +145,7 @@ describe("Block", () => {
         createPipeInText(),
         "",
         "",
+        false,
         createContext()
       );
       expect(introBlock.content.title).toEqual(
@@ -157,6 +158,7 @@ describe("Block", () => {
         createPipeInHtml(),
         "",
         "",
+        false,
         createContext()
       );
 
@@ -170,6 +172,7 @@ describe("Block", () => {
         "",
         `<ul>${createPipeInHtml({ element: "li" })}<li>Some Value</li</ul>`,
         "",
+        false,
         createContext()
       );
       expect(introBlock.content.contents[0].list).toEqual([

--- a/src/eq_schema/schema/Section/index.js
+++ b/src/eq_schema/schema/Section/index.js
@@ -132,6 +132,7 @@ class Section {
           section.introductionTitle,
           section.introductionContent,
           section.introductionPageDescription,
+          section.repeatingSection,
           ctx
         )
       );

--- a/src/utils/compoundFunctions/index.js
+++ b/src/utils/compoundFunctions/index.js
@@ -2,7 +2,11 @@ const { flow } = require("lodash/fp");
 const { parseContent, getInnerHTMLWithPiping } = require("../HTMLUtils");
 const convertPipes = require("../convertPipes");
 
-const processPipe = (ctx) => flow(convertPipes(ctx), getInnerHTMLWithPiping);
+const processPipe = (ctx, isMultipleChoiceValue = false, isRepeatingSection = false) =>
+  flow(
+    convertPipes(ctx, isMultipleChoiceValue, isRepeatingSection),
+    getInnerHTMLWithPiping
+  );
 
 const wrapContents = (propName) => (content) => {
   if (!propName || propName === "" || !content) {
@@ -17,7 +21,7 @@ const wrapContents = (propName) => (content) => {
   return { [propName]: result };
 };
 
-const reversePipeContent = (ctx) => (data) => {
+const reversePipeContent = (ctx, isMultipleChoiceValue = false, isRepeatingSection = false) => (data) => {
   if (!data) {
     return "";
   }
@@ -29,7 +33,7 @@ const reversePipeContent = (ctx) => (data) => {
       items.list = items.list.map((item) => processPipe(ctx)(item));
     }
     if (items.description) {
-      items.description = processPipe(ctx)(items.description);
+      items.description = processPipe(ctx, isMultipleChoiceValue, isRepeatingSection)(items.description);
     }
     return items;
   });


### PR DESCRIPTION
Fix for repeating section intro block
To test use the PPI schema https://prod.author.eqbs.gcp.onsdigital.uk/#/q/762bb791-8f2e-42c6-bcb0-8e67a02ab1c0/view-survey

Convert it and check the interstitial page. 
The transforms (list to concatanate) should be gone and just normal piping used.