### PR TITLE
fix for piping in lists

### DIFF
--- a/src/utils/compoundFunctions/index.js
+++ b/src/utils/compoundFunctions/index.js
@@ -30,7 +30,7 @@ const reversePipeContent = (ctx, isMultipleChoiceValue = false, isRepeatingSecti
 
   content.map((items) => {
     if (items.list) {
-      items.list = items.list.map((item) => processPipe(ctx)(item));
+      items.list = items.list.map((item) => processPipe(ctx, isMultipleChoiceValue, isRepeatingSection)(item));
     }
     if (items.description) {
       items.description = processPipe(ctx, isMultipleChoiceValue, isRepeatingSection)(items.description);


### PR DESCRIPTION
This PR address the piping issue in section intro page descrption where supplementary data was being seperated by commas.

To test.

- create questionnaire
- link to supplementary data
- add a repeating section and link to supplementary data
- in the section intro description add a bulleted list and pipe in a list value from the supplementary data
- Check the published output is now not using a transform