### PR TITLE
fix for piping supp data in answer label

### DIFF
--- a/src/eq_schema/schema/Answer/index.js
+++ b/src/eq_schema/schema/Answer/index.js
@@ -19,6 +19,7 @@ const { unitConversion } = require("../../../constants/units");
 const { getValueSource } = require("../../builders/valueSource");
 
 const { buildContents } = require("../../../utils/builders");
+const { getSectionByAnswerId } = require("../../../utils/functions/sectionGetters")
 
 const multipleChoiceAnswers = [CHECKBOX, RADIO, SELECT, MUTUALLY_EXCLUSIVE];
 
@@ -37,11 +38,12 @@ class Answer {
     this.id = `answer${answer.id}`;
     this.mandatory = answer.properties.required;
     this.type = getAnswerType(answer.type);
+    const section = getSectionByAnswerId(ctx, answer.id) || {}
 
     if (answer.label) {
-      this.label = buildContents(answer.label, ctx);
+      this.label = buildContents(answer.label, ctx, false, section.repeatingSection);
     }
-
+    
     if (answer.description) {
       this.description = buildContents(answer.description, ctx);
     }

--- a/src/eq_schema/schema/Answer/index.js
+++ b/src/eq_schema/schema/Answer/index.js
@@ -43,7 +43,7 @@ class Answer {
     if (answer.label) {
       this.label = buildContents(answer.label, ctx, false, section.repeatingSection);
     }
-    
+
     if (answer.description) {
       this.description = buildContents(answer.description, ctx);
     }

--- a/src/utils/functions/sectionGetters.js
+++ b/src/utils/functions/sectionGetters.js
@@ -14,4 +14,25 @@ const getSectionByPageId = (ctx, pageId) => {
   return result;
 };
 
-module.exports = { getSectionByPageId };
+const getSectionByAnswerId = (ctx, answerId) => {
+  let result;
+  if (ctx && ctx.questionnaireJson && ctx.questionnaireJson.sections) {
+    ctx.questionnaireJson.sections.forEach((section) => {
+      section.folders.forEach((folder) => {
+        folder.pages.forEach((page) => {
+          if (page.answers) {
+            page.answers.forEach((answer) => {
+              if (answer.id === answerId) {
+                result = section;
+              }
+            });
+          }
+        });
+      });
+    });
+  }
+  return result;
+};
+
+
+module.exports = { getSectionByPageId, getSectionByAnswerId };


### PR DESCRIPTION
When piping in a supplementary list item into a answer label the output is being comma seperated.

To test

- Link to supp data 
- create a repeating section and link to supp data
- pipe a list item into an answer label
- view to see commas have been removed.